### PR TITLE
feat: Implement modular wallet disconnect handling, supabase session …

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -7,6 +7,7 @@ import { Footer } from "@/components/footer"
 import { PresenceIndicator, type PresenceStatus } from "@/components/presence-indicator"
 import ConnectWallet from "@/components/wallet-connector"
 import { cn } from "@/lib/utils"
+import { getPublicKey, onDisconnect } from "@/app/stellar-wallet-kit"
 import {
   Search,
   MessageCircle,
@@ -45,21 +46,32 @@ export default function ChatPage() {
   const [selectedChatId, setSelectedChatId] = useState<string | null>(null)
   const [query, setQuery] = useState("")
 
-  // TODO: Replace with real wallet state once wired
   const [walletConnected, setWalletConnected] = useState(false)
+  const [userAddress, setUserAddress] = useState<string | null>(null)
 
-  // Detect wallet connection heuristically from DOM changes of ConnectWallet
+  // Sync wallet state properly
   useEffect(() => {
-    const el = document.getElementById("connect-wrap")
-    if (!el) return
+    const checkWallet = async () => {
+      const address = await getPublicKey()
+      setWalletConnected(!!address)
+      setUserAddress(address)
+    }
 
-    const observer = new MutationObserver(() => {
-      const hasAddress = el.textContent && el.textContent.includes("...")
-      setWalletConnected(Boolean(hasAddress))
+    checkWallet()
+
+    // Listen for disconnects
+    const unsubscribe = onDisconnect(() => {
+      setWalletConnected(false)
+      setUserAddress(null)
     })
 
-    observer.observe(el, { childList: true, subtree: true, characterData: true })
-    return () => observer.disconnect()
+    // Heuristic: Check on interval or simple event as well since kit doesn't have onConnect yet
+    const interval = setInterval(checkWallet, 1000)
+
+    return () => {
+      unsubscribe()
+      clearInterval(interval)
+    }
   }, [])
 
   const chats: ChatPreview[] = useMemo(
@@ -244,7 +256,7 @@ export default function ChatPage() {
                       Connected
                     </span>
                     <span className="text-[11px] font-mono text-foreground">
-                      0×7a3...f2c1
+                      {userAddress ? `${userAddress.slice(0, 6)}...${userAddress.slice(-4)}` : "None"}
                     </span>
                   </div>
                 </div>
@@ -292,7 +304,7 @@ export default function ChatPage() {
                           className={cn(
                             "w-full px-3.5 py-2.5 flex gap-3 items-center text-left hover:bg-[#181824] transition",
                             isSelected &&
-                              "bg-[#19192a] border-l-2 border-primary/80 shadow-[0_0_0_1px_rgba(168,85,247,0.4)]",
+                            "bg-[#19192a] border-l-2 border-primary/80 shadow-[0_0_0_1px_rgba(168,85,247,0.4)]",
                           )}
                         >
                           <div className="relative">

--- a/components/wallet-connector.tsx
+++ b/components/wallet-connector.tsx
@@ -3,19 +3,21 @@
 import { connect, disconnect, getPublicKey } from "@/app/stellar-wallet-kit";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
+import { createClient } from "@/lib/supabase/client";
 
 export default function ConnectWallet() {
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const supabase = createClient();
 
   async function showConnected() {
     const key = await getPublicKey();
     if (key) {
       setPublicKey(key);
 
-      {/* Wallet connection toast */}
-      toast.success("Wallet connected successfully",{
-         duration:2000
+      {/* Wallet connection toast */ }
+      toast.success("Wallet connected successfully", {
+        duration: 2000
       });
     } else {
       setPublicKey(null);
@@ -26,10 +28,18 @@ export default function ConnectWallet() {
   async function showDisconnected() {
     setPublicKey(null);
     setLoading(false);
-     {/* Wallet disconnection toast */}
+
+    // Clear Supabase session on disconnect
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error("Error signing out from Supabase:", error);
+    }
+
+    {/* Wallet disconnection toast */ }
     toast("Wallet disconnected successfully", {
       icon: "🔌",
-      duration:2000
+      duration: 2000
     });
   }
 
@@ -51,10 +61,10 @@ export default function ConnectWallet() {
             className="ellipsis bg-linear-to-r from-primary to-accent p-2 rounded-2xl"
             title={publicKey}
           >
-            {publicKey.slice(0, 4)}...${publicKey.slice(-4)}
+            {publicKey.slice(0, 4)}...{publicKey.slice(-4)}
           </div>
           <button
-            className="bg-linear-to-r from-primary/50 to-accent/70 p-2 rounded-xl"
+            className="bg-linear-to-r from-primary/50 to-accent/70 p-2 rounded-xl h-10 px-4 self-center"
             onClick={() => disconnect(showDisconnected)}
           >
             Disconnect


### PR DESCRIPTION

🎯 Description
This PR addresses the requirement for robust wallet disconnection handling. It introduces a modular event-driven approach to ensure the UI and backend sessions (Supabase) stay synchronized with the user's wallet state.

🛠️ Key Changes
1. Global Disconnect Event Subscriber
Added a 
onDisconnect
 subscriber pattern to 
app/stellar-wallet-kit.tsx
.
This allows multiple components (like the Chat page and the Header) to react to disconnection events without being tightly coupled to each other.
2. Secure Session Clearing
Modified 
components/wallet-connector.tsx
 to include supabase.auth.signOut() in the disconnection flow.
Ensures that when a wallet is disconnected, the Supabase session is immediately terminated to prevent stale authenticated states.
3. Chat UI Refactor
Removed Hacky Logic: Replaced the previous MutationObserver code in 
app/chat/page.tsx
 with a clean useEffect that uses the new kit listeners.
Real Address Display: Updated the Chat sidebar to display the actual truncated public key (e.g., GBV3...R4S1) of the connected wallet instead of a hardcoded placeholder.
Real-time Sync: Added an interval check to ensure the UI remains accurate if the user disconnects directly via their wallet extension (e.g., Freighter).
4. Code Quality & Maintenance
Fixed TypeScript linting errors (explicit any types for wallet options).
Successfully verified dependency tree stability with npm install.
✅ Checklist
 Wallet disconnection clears localStorage.
 Supabase signOut is called successfully.
 UI updates immediately across all screens on disconnect.
 Sidebar displays real wallet address.
 Verified code passes manual inspections and type checks.
How to test:
Connect your Stellar wallet (Freighter, etc.).
Navigate to the /chat page.
Observe your actual wallet address in the sidebar.
Click "Disconnect" in the header.
Verify: You should see a toast notification, the address should disappear, and the chat state should reset to "Disconnected".

closes #50 