### PR TITLE
feat: Restrict message read access to active room members only

### DIFF
--- a/scripts/007_secure_messages_rls.sql
+++ b/scripts/007_secure_messages_rls.sql
@@ -1,0 +1,15 @@
+-- Secure messages table: Only room members can read messages
+-- Drop the temporary policy allowing anyone to read
+DROP POLICY IF EXISTS "Users can view messages in rooms they're in" ON public.messages;
+
+-- Recreate policy requiring the user exist in room_members actively
+CREATE POLICY "Users can view messages in rooms they're in"
+  ON public.messages FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.room_members rm
+      WHERE rm.room_id = messages.room_id
+        AND rm.user_id = auth.uid()
+        AND rm.removed_at IS NULL
+    )
+  );


### PR DESCRIPTION
Closes #42

---

I worked on #42
Where i Prevented Unauthorized Wallet Access to Groups