### PR TITLE
feat(groups): tie group ownership to Stellar wallet with on-chain val…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ AnonChat is a decentralized, privacy-first chat application where:
 * Users **connect using a Web3 wallet**
 * No personal data, email, or phone number is required
 * Users can **create or join anonymous groups**
+
+### On-Chain Group Ownership
+To improve security, each chat group is now tied to a specific Stellar wallet address. The wallet that creates a group becomes its owner, and only that wallet can change the group's metadata. When a new room is created the owner's address is saved in the database and included in the metadata hash that is submitted to the Stellar blockchain.
+
+Updates to a group's name, description or privacy flag must be accompanied by a signature from the owner's wallet. The backend verifies the signature against the proposed new metadata and rejects unauthorized requests. This provides transparent, on-chain proof of who controls a community.
+
 * Messages are **end-to-end encrypted**
 * Identity is never exposed — not even to us
 

--- a/app/api/rooms/[roomId]/route.ts
+++ b/app/api/rooms/[roomId]/route.ts
@@ -1,0 +1,216 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { computeHash } from "@/lib/blockchain/metadata-hash";
+import {
+  submitMetadataHash,
+  getTransactionExplorerUrl,
+} from "@/lib/blockchain/stellar-service";
+import { verifyWalletSignature } from "@/lib/auth/stellar-verify";
+import { GroupMetadata } from "@/types/blockchain";
+import {
+  logBlockchainOperation,
+  generateCorrelationId,
+} from "@/lib/blockchain/logger";
+
+// GET /api/rooms/[roomId] - fetch basic room record
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+) {
+  const correlationId = generateCorrelationId();
+  const { roomId } = await params;
+
+  try {
+    const supabase = await createClient();
+    const { data: room, error } = await supabase
+      .from("rooms")
+      .select("*")
+      .eq("id", roomId)
+      .single();
+
+    if (error || !room) {
+      return NextResponse.json({ error: "Room not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ room });
+  } catch (err: any) {
+    console.error(`[v0] GET /api/rooms/${roomId} error:`, err);
+    logBlockchainOperation(
+      "error",
+      "Failed to fetch room",
+      { groupId: roomId, error: err },
+      correlationId,
+    );
+    return NextResponse.json(
+      { error: "Failed to fetch room" },
+      { status: 500 },
+    );
+  }
+}
+
+// PATCH /api/rooms/[roomId] - update metadata, requires owner signature
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+) {
+  const correlationId = generateCorrelationId();
+  const { roomId } = await params;
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const walletAddress =
+      (user.user_metadata as any)?.wallet_address as string | undefined;
+    if (!walletAddress) {
+      return NextResponse.json(
+        { error: "Wallet address not available for user" },
+        { status: 403 },
+      );
+    }
+
+    const body = await request.json();
+    const { name, description, is_private, max_fee, signature } = body;
+
+    // signature must be provided
+    if (!signature || typeof signature !== "string") {
+      return NextResponse.json(
+        { error: "signature is required" },
+        { status: 400 },
+      );
+    }
+
+    // fetch existing room to confirm ownership
+    const { data: room, error: fetchError } = await supabase
+      .from("rooms")
+      .select("*")
+      .eq("id", roomId)
+      .single();
+
+    if (fetchError || !room) {
+      return NextResponse.json({ error: "Room not found" }, { status: 404 });
+    }
+
+    if (room.owner_wallet !== walletAddress) {
+      return NextResponse.json({ error: "Wallet not owner" }, { status: 403 });
+    }
+
+    // compute the expected metadata hash for the updated values
+    const newMetadata: GroupMetadata = {
+      id: room.id,
+      name: name !== undefined ? name : room.name,
+      description:
+        description !== undefined ? description : room.description,
+      created_by: room.created_by,
+      created_at: room.created_at,
+      is_private: is_private !== undefined ? is_private : room.is_private,
+      owner_wallet: walletAddress,
+    };
+
+    const newHash = computeHash(newMetadata);
+
+    // verify the signature over the hash
+    const validSig = verifyWalletSignature(walletAddress, newHash, signature);
+    if (!validSig) {
+      return NextResponse.json(
+        { error: "Signature verification failed" },
+        { status: 403 },
+      );
+    }
+
+    // perform update
+    const updates: any = {};
+    if (name !== undefined) updates.name = name;
+    if (description !== undefined) updates.description = description;
+    if (is_private !== undefined) updates.is_private = is_private;
+
+    const { data: updatedRows, error: updateError } = await supabase
+      .from("rooms")
+      .update(updates)
+      .eq("id", roomId)
+      .select();
+
+    if (updateError) throw updateError;
+    const updatedRoom = updatedRows[0];
+
+    // Optionally re-submit to blockchain in background
+    let blockchainSubmitted = false;
+    let stellarTxHash: string | null = null;
+    let explorerUrl: string | null = null;
+    let actualFeeCharged: string | null = null;
+
+    try {
+      const result = await submitMetadataHash(room.id, newHash, max_fee);
+      if (result.success && result.transactionHash) {
+        blockchainSubmitted = true;
+        stellarTxHash = result.transactionHash;
+        actualFeeCharged = result.feeCharged || null;
+        explorerUrl = getTransactionExplorerUrl(result.transactionHash);
+        await supabase
+          .from("rooms")
+          .update({
+            stellar_tx_hash: stellarTxHash,
+            metadata_hash: newHash,
+            blockchain_submitted_at: new Date().toISOString(),
+          })
+          .eq("id", roomId);
+
+        logBlockchainOperation(
+          "info",
+          "Room metadata updated on-chain",
+          { groupId: roomId, transactionHash: stellarTxHash },
+          correlationId,
+        );
+      }
+    } catch (err: any) {
+      logBlockchainOperation(
+        "warn",
+        "On-chain update failed, continuing without it",
+        { groupId: roomId, error: err.message },
+        correlationId,
+      );
+    }
+
+    return NextResponse.json(
+      {
+        room: {
+          ...updatedRoom,
+          stellar_tx_hash: stellarTxHash,
+          metadata_hash: newHash,
+        },
+        success: true,
+        blockchain: {
+          submitted: blockchainSubmitted,
+          transactionHash: stellarTxHash || undefined,
+          feeCharged: actualFeeCharged || undefined,
+          explorerUrl: explorerUrl || undefined,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error: any) {
+    console.error(`[v0] PATCH /api/rooms/${roomId} error:`, error);
+    logBlockchainOperation(
+      "error",
+      "Room update failed",
+      {
+        groupId: roomId,
+        error: {
+          type: error instanceof Error ? error.name : "UnknownError",
+          message: error instanceof Error ? error.message : "Unknown error",
+        },
+      },
+      correlationId,
+    );
+    return NextResponse.json(
+      { error: "Failed to update room" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/rooms/[roomId]/verify/route.ts
+++ b/app/api/rooms/[roomId]/verify/route.ts
@@ -40,6 +40,7 @@ export async function GET(
       created_by: room.created_by,
       created_at: room.created_at,
       is_private: room.is_private,
+      owner_wallet: room.owner_wallet ?? null,
     };
 
     // Compute current metadata hash
@@ -52,6 +53,7 @@ export async function GET(
         groupId: roomId,
         currentMetadataHash,
         storedTxHash: room.stellar_tx_hash,
+        ownerWallet: room.owner_wallet,
       },
       correlationId,
     );
@@ -65,6 +67,7 @@ export async function GET(
         transactionHash: null,
         verified: false,
         explorerUrl: null,
+        owner_wallet: room.owner_wallet ?? null,
       };
 
       return NextResponse.json(response);
@@ -91,6 +94,7 @@ export async function GET(
         transactionHash: room.stellar_tx_hash,
         verified: false,
         explorerUrl: getTransactionExplorerUrl(room.stellar_tx_hash),
+        owner_wallet: room.owner_wallet ?? null,
       };
 
       return NextResponse.json(response);
@@ -121,6 +125,7 @@ export async function GET(
       transactionHash: room.stellar_tx_hash,
       verified,
       explorerUrl: getTransactionExplorerUrl(room.stellar_tx_hash),
+      owner_wallet: room.owner_wallet ?? null,
     };
 
     return NextResponse.json(response);

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -69,8 +69,32 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // Wallet login flow stores the wallet address in user metadata.  We
+    // require that the caller is authenticated with a wallet so we can tie
+    // group ownership to that address.  If no wallet address is present we
+    // reject the request.
+    const walletAddress =
+      (user.user_metadata as any)?.wallet_address as string | undefined;
+    if (!walletAddress) {
+      return NextResponse.json(
+        { error: "Wallet address not available for user" },
+        { status: 403 },
+      );
+    }
+
     const body = await request.json();
-    const { name, description, is_private, max_fee } = body;
+    const { name, description, is_private, max_fee, wallet_address } = body;
+
+    // if the client supplied a wallet_address make sure it matches the one we
+    // retrieved from the authenticated user; otherwise ignore.
+    if (wallet_address && wallet_address !== walletAddress) {
+      return NextResponse.json(
+        { error: "wallet_address mismatch" },
+        { status: 400 },
+      );
+    }
+
+    const wAddr = wallet_address || walletAddress;
 
     if (!name) {
       return NextResponse.json({ error: "name is required" }, { status: 400 });
@@ -79,7 +103,7 @@ export async function POST(request: NextRequest) {
     const roomId = `room_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
     const createdAt = new Date().toISOString();
 
-    // Insert group into database first
+    // Insert group into database first (owner_wallet added)
     const { data, error } = await supabase
       .from("rooms")
       .insert({
@@ -88,6 +112,7 @@ export async function POST(request: NextRequest) {
         description,
         is_private: is_private || false,
         created_by: user.id,
+        owner_wallet: wAddr,
       })
       .select();
 
@@ -95,7 +120,7 @@ export async function POST(request: NextRequest) {
 
     const room = data[0];
 
-    // Prepare metadata for blockchain submission
+    // Prepare metadata for blockchain submission, include owner wallet
     const metadata: GroupMetadata = {
       id: room.id,
       name: room.name,
@@ -103,6 +128,7 @@ export async function POST(request: NextRequest) {
       created_by: room.created_by,
       created_at: room.created_at,
       is_private: room.is_private,
+      owner_wallet: room.owner_wallet,
     };
 
     // Compute metadata hash

--- a/app/api/rooms/seed-test/route.ts
+++ b/app/api/rooms/seed-test/route.ts
@@ -16,6 +16,9 @@ export async function POST(request: NextRequest) {
 
     const roomId = `room_${Date.now()}_${Math.random().toString(36).substr(2, 6)}`
 
+    const walletAddress =
+      (user.user_metadata as any)?.wallet_address as string | undefined;
+
     const { data: room, error: roomError } = await supabase
       .from("rooms")
       .insert({
@@ -24,6 +27,7 @@ export async function POST(request: NextRequest) {
         description: "Seeded test room for quick joining",
         is_private: false,
         created_by: user.id,
+        owner_wallet: walletAddress || null,
       })
       .select()
 

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -64,6 +64,7 @@ interface DBRoom {
   name: string;
   description?: string;
   created_at: string;
+  owner_wallet?: string;
   address?: string;
   unread_count?: number;
 }
@@ -207,7 +208,10 @@ export default function ChatPage() {
           const mappedRooms: ChatPreview[] = data.rooms.map((r: DBRoom) => ({
             id: r.id,
             name: r.name,
-            address: r.address || (r.id.slice(0, 8) + "..."),
+            // display the owner&apos;s wallet address if we have it
+            address: r.owner_wallet
+              ? `${r.owner_wallet.slice(0, 4)}...${r.owner_wallet.slice(-4)}`
+              : r.address || (r.id.slice(0, 8) + "..."),
             lastMessage: r.description || "No messages yet",
             lastSeen: new Date(r.created_at).toLocaleDateString(),
             unreadCount: r.unread_count || 0,

--- a/components/create-group-modal.tsx
+++ b/components/create-group-modal.tsx
@@ -67,6 +67,9 @@ export function CreateGroupModal() {
       toast.error("Please connect your wallet first");
       return;
     }
+    // we expect the Supabase session to be tied to the same wallet; if the
+    // user hasn't authenticated with our backend yet the POST call will
+    // return 401/403 and we simply display a generic error below.
 
     if (!groupName.trim()) {
       toast.error("Group name is required");
@@ -84,7 +87,8 @@ export function CreateGroupModal() {
           name: groupName,
           description: `Group created by ${publicKey.slice(0, 4)}...${publicKey.slice(-4)}`,
           is_private: false,
-          max_fee: networkFee
+          max_fee: networkFee,
+          wallet_address: publicKey,
         })
       });
 

--- a/scripts/008_add_owner_wallet_to_rooms.sql
+++ b/scripts/008_add_owner_wallet_to_rooms.sql
@@ -1,0 +1,32 @@
+-- Add an owner_wallet column to rooms so ownership can be tied to a
+-- Stellar wallet address.  Existing rows will have NULL; new inserts
+-- must provide a value via the application logic.
+
+alter table if exists public.rooms
+  add column if not exists owner_wallet text;
+
+-- You may want to index by wallet for fast lookups later.
+create index if not exists rooms_owner_wallet_idx on public.rooms(owner_wallet);
+
+-- Row-level security policies need minor tweaks so that the wallet
+-- address recorded on the room actually corresponds to the wallet tied to
+-- the current JWT.  This prevents a malicious client from inserting an
+-- arbitrary owner_wallet value.
+
+-- upgrade insert policy to check the jwt metadata
+create policy if not exists "Users can create rooms"
+  on public.rooms for insert
+  with check (
+    auth.uid() = created_by
+    and owner_wallet is not null
+    and owner_wallet = (auth.jwt() ->> 'user_metadata' ->> 'wallet_address')
+  );
+
+-- update policy should similarly verify the wallet matches; existing
+-- policy is redefined here for clarity
+create policy if not exists "Room creators can update their rooms"
+  on public.rooms for update
+  using (
+    auth.uid() = created_by
+    and owner_wallet = (auth.jwt() ->> 'user_metadata' ->> 'wallet_address')
+  );

--- a/types/blockchain.ts
+++ b/types/blockchain.ts
@@ -7,6 +7,9 @@ export interface GroupMetadata {
   created_by: string;
   created_at: string;
   is_private: boolean;
+  // the Stellar wallet address that owns this group
+  // newer groups will always have a value here; existing records may be null
+  owner_wallet?: string | null;
 }
 
 export interface StellarTransactionResult {
@@ -30,6 +33,7 @@ export interface VerificationResponse {
   transactionHash: string | null;
   verified: boolean;
   explorerUrl: string | null;
+  owner_wallet?: string | null;
 }
 
 export interface GroupCreationResponse {
@@ -40,6 +44,7 @@ export interface GroupCreationResponse {
     is_private: boolean;
     created_by: string;
     created_at: string;
+    owner_wallet?: string | null;
     stellar_tx_hash: string | null;
     metadata_hash?: string | null;
     blockchain_submitted_at?: string | null;


### PR DESCRIPTION
…idation
Summary
Groups are now owned by a specific Stellar wallet address. Ownership is recorded in the database and baked into the metadata hash submitted to the Stellar blockchain. Only the wallet that created a group can modify its metadata.

Key changes

Added [owner_wallet](https://shiny-space-xylophone-pj779x77v5vq29499.github.dev/) column to [rooms](https://shiny-space-xylophone-pj779x77v5vq29499.github.dev/) (with migration script).
Updated TypeScript types for metadata, creation & verification responses.
[POST /api/rooms](https://shiny-space-xylophone-pj779x77v5vq29499.github.dev/) stores owner wallet and validates against authenticated user.
New [PATCH /api/rooms/[roomId]](https://shiny-space-xylophone-pj779x77v5vq29499.github.dev/) endpoint handles metadata updates:
Confirms wallet ownership.
Requires signature over updated metadata hash.
Optional on‑chain re‑submission.
Verification endpoint now includes owner wallet.
Enhanced row‑level security policies enforce wallet/JWT integrity.
Front‑end adjustments: wallet address in room lists, creation flow sends wallet info.
README documentation added for the new ownership model.
Why
Ensures only rightful wallet owners can change group data, providing transparent, on‑chain proof of ownership and strengthening overall trust/security.

closes #39