### PR TITLE
fix: implement WebSocket-based group message broadcasting

### DIFF
--- a/lib/websocket/client.ts
+++ b/lib/websocket/client.ts
@@ -206,7 +206,7 @@ export class WebSocketClient {
 
   joinRoom(roomId: string) {
     this.send({
-      type: "room_join",
+      type: "join_room",
       payload: { roomId },
       timestamp: Date.now(),
     })

--- a/lib/websocket/server.ts
+++ b/lib/websocket/server.ts
@@ -40,9 +40,9 @@ export function createWebSocketServer(port: number = 3001) {
     if (!room) return
 
     const messageStr = JSON.stringify(message)
-    room.users.forEach((userId) => {
-      const client = clients.get(userId)
-      if (client && client.ws.readyState === WebSocket.OPEN && userId !== excludeClientId) {
+    room.users.forEach((clientId) => {
+      const client = clients.get(clientId)
+      if (client && client.ws.readyState === WebSocket.OPEN && clientId !== excludeClientId) {
         client.ws.send(messageStr)
       }
     })
@@ -58,10 +58,12 @@ export function createWebSocketServer(port: number = 3001) {
   }
 
   function sendToUser(userId: string, message: any) {
-    const client = clients.get(userId)
-    if (client && client.ws.readyState === WebSocket.OPEN) {
-      client.ws.send(JSON.stringify(message))
-    }
+    const messageStr = JSON.stringify(message)
+    clients.forEach((client) => {
+      if (client.userId === userId && client.ws.readyState === WebSocket.OPEN) {
+        client.ws.send(messageStr)
+      }
+    })
   }
 
   function setupHeartbeat(clientId: string) {
@@ -88,6 +90,13 @@ export function createWebSocketServer(port: number = 3001) {
       client.ws.close()
     }
     clients.delete(clientId)
+
+    // Remove from all rooms
+    rooms.forEach((room) => {
+      if (room.users.has(clientId)) {
+        room.users.delete(clientId)
+      }
+    })
 
     // Notify about presence update
     if (client?.userId) {
@@ -173,7 +182,7 @@ export function createWebSocketServer(port: number = 3001) {
               rooms.set(roomId, { id: roomId, users: new Set() })
             }
 
-            rooms.get(roomId)?.users.add(userId)
+            rooms.get(roomId)?.users.add(clientId)
 
             // Notify room members
             broadcastToRoom(roomId, {
@@ -193,7 +202,7 @@ export function createWebSocketServer(port: number = 3001) {
             const leaveUserId = connection.userId
 
             if (leaveUserId && rooms.has(leaveRoomId)) {
-              rooms.get(leaveRoomId)?.users.delete(leaveUserId)
+              rooms.get(leaveRoomId)?.users.delete(clientId)
 
               broadcastToRoom(leaveRoomId, {
                 type: "room_leave",


### PR DESCRIPTION
- Fix event type mismatch: client now sends 'join_room' (was 'room_join')
- Fix broadcastToRoom to store and iterate over clientId (not userId) so clients.get(clientId) resolves correctly on every broadcast
- Fix leave_room handler to remove clientId from room member set
- Fix cleanupClient to evict disconnected clientId from all rooms, preventing stale entries and sends to dead sockets
- Fix sendToUser to scan clients map by userId rather than direct key lookup (map is keyed by clientId, not userId)

All 10 live integration tests pass (server start, connection, auth, room join/leave notifications, message broadcast to all members, typing indicators, wallet events, connection stability).

Acceptance criteria met:
- Messages delivered instantly via WebSocket broadcast
- Only sent to group members (room-scoped broadcastToRoom)
- Handles multiple simultaneous users correctly

CLOSES #109