### PR TITLE
feat: Implement   message delivery status (Sent/Delivered) #110

### DIFF
--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -56,6 +56,51 @@ export async function GET(request: NextRequest) {
   }
 }
 
+export async function PATCH(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const { id, status } = body
+
+    if (!id || !status) {
+      return NextResponse.json({ error: "id and status are required" }, { status: 400 })
+    }
+
+    // Only allow updating to certain statuses
+    if (!["sent", "delivered", "read"].includes(status)) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 })
+    }
+
+    // Verify message exists and user has access (implicitly via RLS or explicit check)
+    // For simplicity and matching existing patterns, we'll just attempt the update
+    // Supabase RLS should handle permission if configured
+    const { data, error } = await supabase
+      .from("messages")
+      .update({ status })
+      .eq("id", id)
+      .select()
+
+    if (error) throw error
+
+    if (!data || data.length === 0) {
+      return NextResponse.json({ error: "Message not found" }, { status: 404 })
+    }
+
+    return NextResponse.json({ message: data[0], success: true })
+  } catch (error) {
+    console.error("[v0] PATCH /api/messages error:", error)
+    return NextResponse.json({ error: "Failed to update message status" }, { status: 500 })
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient()
@@ -105,6 +150,7 @@ export async function POST(request: NextRequest) {
         room_id,
         content,
         is_encrypted: false,
+        status: "sent",
       })
       .select()
 

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -53,6 +53,7 @@ interface DBMessage {
   user_id: string;
   content: string;
   created_at: string;
+  status?: "sent" | "delivered" | "read";
 }
 
 export default function ChatPage() {
@@ -86,7 +87,7 @@ export default function ChatPage() {
         minute: "2-digit",
         hour12: false,
       }),
-      status: "read",
+      status: message.status || "sent",
     }),
     [currentUser?.id],
   );
@@ -565,7 +566,8 @@ export default function ChatPage() {
                             <span>{message.time}</span>
                             {message.author === "me" && (
                               <span aria-label={`Delivery status: ${message.status}`}>
-                                {message.status === "sending" ? "..." : "✓✓"}
+                                {message.status === "sending" ? "..." : 
+                                 message.status === "sent" ? "✓" : "✓✓"}
                               </span>
                             )}
                           </div>

--- a/lib/websocket/chat-hooks.tsx
+++ b/lib/websocket/chat-hooks.tsx
@@ -38,6 +38,7 @@ export function useRealtimeChat(roomId: string, userId?: string) {
     sendMessage,
     joinRoom,
     leaveRoom,
+    markAsDelivered,
     notifyTyping,
     notifyStopTyping,
   } = useWebSocketSend()
@@ -60,6 +61,31 @@ export function useRealtimeChat(roomId: string, userId?: string) {
     if ((msg.payload as any).roomId === roomId) {
       const messagePayload = msg.payload as any as RealtimeMessageUpdate
       setMessages((prev) => [...prev, messagePayload])
+
+      // Automatically mark as delivered if it's from someone else
+      if (messagePayload.userId !== userId) {
+        // Send WebSocket ack
+        markAsDelivered(messagePayload.id, roomId)
+
+        // Also update database via API for persistence
+        fetch("/api/messages", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: messagePayload.id, status: "delivered" }),
+        }).catch((err) => console.error("Failed to persist delivery status:", err))
+      }
+    }
+  })
+
+  // Listen for message status updates
+  useWebSocketMessage("message_status_update", (msg: WebSocketMessage) => {
+    const payload = msg.payload as any
+    if (payload.roomId === roomId) {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === payload.messageId ? { ...m, status: payload.status } : m,
+        ),
+      )
     }
   })
 

--- a/lib/websocket/client.ts
+++ b/lib/websocket/client.ts
@@ -242,6 +242,14 @@ export class WebSocketClient {
     return { success: true }
   }
 
+  markAsDelivered(messageId: string, roomId: string) {
+    this.send({
+      type: "message_delivered",
+      payload: { messageId, roomId },
+      timestamp: Date.now(),
+    })
+  }
+
   notifyTyping(roomId: string) {
     this.send({
       type: "typing",

--- a/lib/websocket/hooks.ts
+++ b/lib/websocket/hooks.ts
@@ -131,6 +131,9 @@ export function useWebSocketSend() {
     sendMessage: useCallback((roomId: string, content: string) => {
       return client.current.sendMessage(roomId, content)
     }, []),
+    markAsDelivered: useCallback((messageId: string, roomId: string) => {
+      client.current.markAsDelivered(messageId, roomId)
+    }, []),
     notifyTyping: useCallback((roomId: string) => {
       client.current.notifyTyping(roomId)
     }, []),

--- a/lib/websocket/server.ts
+++ b/lib/websocket/server.ts
@@ -240,6 +240,24 @@ export function createWebSocketServer(port: number = 3001) {
             break
           }
 
+          case "message_delivered": {
+            const deliveredRoomId = message.payload.roomId
+            const deliveredMessageId = message.payload.messageId
+
+            // Broadcast status update to the room
+            // In a production app, we would also update the database here
+            broadcastToRoom(deliveredRoomId, {
+              type: "message_status_update",
+              payload: {
+                messageId: deliveredMessageId,
+                status: "delivered",
+                roomId: deliveredRoomId,
+              },
+              timestamp: Date.now(),
+            })
+            break
+          }
+
           case "typing": {
             const typingRoomId = message.payload.roomId
 

--- a/lib/websocket/utils.ts
+++ b/lib/websocket/utils.ts
@@ -73,6 +73,19 @@ export function sendWebSocketMessage(roomId: string, content: string) {
 }
 
 /**
+ * Marks a message as delivered via WebSocket
+ */
+export function markWebSocketMessageDelivered(messageId: string, roomId: string) {
+  const client = getWebSocketClient()
+
+  if (!client.isConnected()) {
+    return
+  }
+
+  client.markAsDelivered(messageId, roomId)
+}
+
+/**
  * Notifies that the user is typing
  */
 export function notifyWebSocketTyping(roomId: string) {

--- a/scripts/010_message_status.sql
+++ b/scripts/010_message_status.sql
@@ -1,0 +1,8 @@
+-- Add status column to messages table
+ALTER TABLE public.messages ADD COLUMN IF NOT EXISTS status text DEFAULT 'sent';
+
+-- Create an index for faster status filtering if needed
+CREATE INDEX IF NOT EXISTS messages_status_idx ON public.messages(status);
+
+-- Update existing messages to 'sent' status if they don't have one
+UPDATE public.messages SET status = 'sent' WHERE status IS NULL;

--- a/types/websocket.ts
+++ b/types/websocket.ts
@@ -1,6 +1,7 @@
 // Server-to-client event types
 export type WebSocketServerEventType =
   | "message"
+  | "message_status_update"
   | "room_join"
   | "room_leave"
   | "user_typing"
@@ -17,6 +18,7 @@ export type WebSocketClientEventType =
   | "join_room"
   | "leave_room"
   | "send_message"
+  | "message_delivered"
   | "typing"
   | "stop_typing"
   | "wallet_event"


### PR DESCRIPTION
This PR introduces tracking and display of message delivery states. Messages are now marked as "Sent" upon DB persistence and "Delivered" once received by the recipient's client via WebSocket.

  Changes:
   - Added status column to messages table via migration 010_message_status.sql.
   - Extended WebSocket protocol with message_delivered and message_status_update events.
   - Added PATCH /api/messages endpoint for persisting status updates.
   - Updated useRealtimeChat hook to automatically acknowledge message delivery.
   - Updated ChatPage UI to display status indicators (✓ for sent, ✓✓ for delivered).

  How to test:
   1. Run the migration: psql $DATABASE_URL -f scripts/010_message_status.sql.
   2. Start the app and WebSocket server: npm run dev:all.
   3. Open the chat in two different browser sessions/tabs.
   4. Send a message from Session A. It should show ✓.
   5. Observe Session B receiving the message.
   6. Check Session A: The message status should update to ✓✓.

  Notes:
   - Minimal changes to existing REST logic to ensure backward compatibility.
   - Uses a hybrid approach (WebSocket for speed, REST for persistence) to guarantee reliability.

  Closes #110 