### PR TITLE
feat: implement group join via invite code API (#111)

### DIFF
--- a/app/api/groups/[id]/invite/route.ts
+++ b/app/api/groups/[id]/invite/route.ts
@@ -1,0 +1,117 @@
+import { createClient } from "@/lib/supabase/server"
+import { type NextRequest, NextResponse } from "next/server"
+import {
+  generateInviteCode,
+  buildExpiresAt,
+} from "@/lib/groups/invite"
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: groupId } = await params
+
+  if (!groupId) {
+    return NextResponse.json({ error: "Group ID is required" }, { status: 400 })
+  }
+
+  try {
+    const supabase = await createClient()
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    // Verify the group exists
+    const { data: group, error: groupError } = await supabase
+      .from("rooms")
+      .select("id, name, created_by, is_private")
+      .eq("id", groupId)
+      .maybeSingle()
+
+    if (groupError) throw groupError
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 })
+    }
+
+    // Only the group creator or an existing member can generate an invite
+    const isCreator = group.created_by === user.id
+
+    if (!isCreator) {
+      const { data: membership } = await supabase
+        .from("room_members")
+        .select("user_id")
+        .eq("room_id", groupId)
+        .eq("user_id", user.id)
+        .maybeSingle()
+
+      if (!membership) {
+        return NextResponse.json(
+          { error: "Only group members can generate invite codes" },
+          { status: 403 }
+        )
+      }
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const { expires_in, max_uses } = body as {
+      expires_in?: number
+      max_uses?: number
+    }
+
+    if (max_uses !== undefined && (!Number.isInteger(max_uses) || max_uses < 1)) {
+      return NextResponse.json(
+        { error: "max_uses must be a positive integer" },
+        { status: 400 }
+      )
+    }
+
+    if (expires_in !== undefined && (!Number.isInteger(expires_in) || expires_in < 1)) {
+      return NextResponse.json(
+        { error: "expires_in must be a positive integer (seconds)" },
+        { status: 400 }
+      )
+    }
+
+    const code = generateInviteCode()
+    const expiresAt = buildExpiresAt(expires_in)
+
+    const { data: invite, error: insertError } = await supabase
+      .from("invites")
+      .insert({
+        code,
+        room_id: groupId,
+        created_by: user.id,
+        expires_at: expiresAt,
+        max_uses: max_uses ?? null,
+        use_count: 0,
+      })
+      .select("code, room_id, created_at, expires_at, max_uses")
+      .single()
+
+    if (insertError) throw insertError
+
+    console.info(`[groups/invite] Invite code generated for group ${groupId} by user ${user.id}`)
+
+    return NextResponse.json(
+      {
+        success: true,
+        invite: {
+          code: invite.code,
+          group_id: invite.room_id,
+          created_at: invite.created_at,
+          expires_at: invite.expires_at,
+          max_uses: invite.max_uses,
+        },
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    console.error(`[groups/invite] POST /api/groups/${groupId}/invite error:`, error)
+    return NextResponse.json({ error: "Failed to generate invite code" }, { status: 500 })
+  }
+}

--- a/app/api/groups/join/route.ts
+++ b/app/api/groups/join/route.ts
@@ -1,0 +1,82 @@
+import { createClient } from "@/lib/supabase/server"
+import { type NextRequest, NextResponse } from "next/server"
+import { validateInviteCode, incrementInviteUseCount } from "@/lib/groups/invite"
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    if (!body) {
+      return NextResponse.json({ error: "Request body is required" }, { status: 400 })
+    }
+
+    const { code } = body as { code?: string }
+
+    const validation = await validateInviteCode(supabase, code ?? "")
+
+    if (!validation.valid) {
+      console.warn(
+        `[groups/join] Invalid invite attempt — user: ${user.id}, code: ${code ?? "(none)"}, reason: ${validation.error}`
+      )
+      return NextResponse.json({ error: validation.error }, { status: validation.status })
+    }
+
+    const { roomId, inviteCode } = validation
+
+    // Verify the group still exists
+    const { data: group } = await supabase
+      .from("rooms")
+      .select("id, name")
+      .eq("id", roomId)
+      .maybeSingle()
+
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 })
+    }
+
+    // Insert membership record
+    const { data: membership, error: membershipError } = await supabase
+      .from("room_members")
+      .insert({ user_id: user.id, room_id: roomId })
+      .select("user_id, room_id, joined_at")
+      .single()
+
+    if (membershipError) {
+      // Unique constraint violation — user is already a member
+      if (membershipError.code === "23505") {
+        console.info(`[groups/join] User ${user.id} is already a member of group ${roomId}`)
+        return NextResponse.json({ success: true, message: "Already a member" })
+      }
+      throw membershipError
+    }
+
+    // Atomically increment invite usage count (non-blocking on failure)
+    await incrementInviteUseCount(supabase, inviteCode)
+
+    console.info(
+      `[groups/join] User ${user.id} joined group ${roomId} via invite code ${inviteCode}`
+    )
+
+    return NextResponse.json({
+      success: true,
+      group: { id: group.id, name: group.name },
+      membership: {
+        user_id: membership.user_id,
+        group_id: membership.room_id,
+        joined_at: membership.joined_at,
+      },
+    })
+  } catch (error) {
+    console.error("[groups/join] POST /api/groups/join error:", error)
+    return NextResponse.json({ error: "Failed to join group" }, { status: 500 })
+  }
+}

--- a/lib/groups/invite.ts
+++ b/lib/groups/invite.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from "crypto"
+import { SupabaseClient } from "@supabase/supabase-js"
+
+export type InviteValidationResult =
+  | { valid: true; roomId: string; inviteCode: string }
+  | { valid: false; status: 400 | 404 | 410 | 429 | 500; error: string }
+
+export interface GenerateInviteOptions {
+  /** Seconds from now until the code expires. Omit for no time-based expiry. */
+  expiresIn?: number
+  /** Maximum number of times this code can be used. Omit for unlimited. */
+  maxUses?: number
+}
+
+export interface InviteRecord {
+  code: string
+  room_id: string
+  created_by: string
+  created_at: string
+  expires_at: string | null
+  max_uses: number | null
+  use_count: number
+}
+
+export function generateInviteCode(): string {
+  return randomUUID()
+}
+
+export function buildExpiresAt(expiresIn?: number): string | null {
+  if (!expiresIn || expiresIn <= 0) return null
+  return new Date(Date.now() + expiresIn * 1000).toISOString()
+}
+
+/**
+ * Validates an invite code and returns the associated room ID on success.
+ * Checks: existence, time-based expiry, and usage-based expiry.
+ */
+export async function validateInviteCode(
+  supabase: SupabaseClient,
+  code: string
+): Promise<InviteValidationResult> {
+  if (!code || typeof code !== "string" || code.trim() === "") {
+    return { valid: false, status: 400, error: "Invite code is required" }
+  }
+
+  const { data: invite, error } = await supabase
+    .from("invites")
+    .select("code, room_id, expires_at, max_uses, use_count")
+    .eq("code", code.trim())
+    .maybeSingle()
+
+  if (error) {
+    console.error("[invite] DB error validating invite code:", error)
+    return { valid: false, status: 500, error: "Failed to validate invite code" }
+  }
+
+  if (!invite) {
+    return { valid: false, status: 404, error: "Invalid invite code" }
+  }
+
+  // Time-based expiration check
+  if (invite.expires_at && new Date(invite.expires_at) < new Date()) {
+    return { valid: false, status: 410, error: "Invite code has expired" }
+  }
+
+  // Usage-based expiration check
+  if (invite.max_uses !== null && invite.use_count >= invite.max_uses) {
+    return { valid: false, status: 410, error: "Invite code has reached its usage limit" }
+  }
+
+  return { valid: true, roomId: invite.room_id, inviteCode: invite.code }
+}
+
+/**
+ * Atomically increments the use_count for a given invite code.
+ * Should be called after a successful group join.
+ */
+export async function incrementInviteUseCount(
+  supabase: SupabaseClient,
+  code: string
+): Promise<void> {
+  const { error } = await supabase.rpc("increment_invite_use_count", { invite_code: code })
+
+  if (error) {
+    // Non-fatal: log but don't block the join response
+    console.error("[invite] Failed to increment use_count for code:", code, error)
+  }
+}

--- a/scripts/011_enhance_invites_for_group_join.sql
+++ b/scripts/011_enhance_invites_for_group_join.sql
@@ -1,0 +1,31 @@
+-- Enhance invites table for group join via invite code (issue #111)
+-- Adds usage-based expiration support and required RLS policies
+
+alter table public.invites
+  add column if not exists max_uses integer,
+  add column if not exists use_count integer not null default 0;
+
+-- Allow any authenticated user to read an invite by code (needed for join validation)
+create policy "Authenticated users can read invites by code"
+  on public.invites for select
+  using (auth.role() = 'authenticated');
+
+-- Allow server to increment use_count on join
+create policy "Authenticated users can update invite use_count"
+  on public.invites for update
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create index if not exists invites_room_id_idx on public.invites(room_id);
+create index if not exists invites_created_by_idx on public.invites(created_by);
+
+-- Atomic increment function to safely track invite usage without race conditions
+create or replace function public.increment_invite_use_count(invite_code text)
+returns void
+language sql
+security definer
+as $$
+  update public.invites
+  set use_count = use_count + 1
+  where code = invite_code;
+$$;

--- a/scripts/MIGRATIONS_README.md
+++ b/scripts/MIGRATIONS_README.md
@@ -11,6 +11,7 @@ Included migrations (apply in numeric order):
 - `005_add_last_read_to_room_members.sql` (new)
 - `006_unread_view.sql`          (new)
 - `007_create_group_membership.sql`  (new)
+- `011_enhance_invites_for_group_join.sql` (new)
 
 ## How to apply (psql)
 
@@ -28,6 +29,7 @@ psql "$DATABASE_URL" -f scripts/004_create_room_members.sql
 psql "$DATABASE_URL" -f scripts/005_add_last_read_to_room_members.sql
 psql "$DATABASE_URL" -f scripts/006_unread_view.sql
 psql "$DATABASE_URL" -f scripts/007_create_group_membership.sql
+psql "$DATABASE_URL" -f scripts/011_enhance_invites_for_group_join.sql
 ```
 
 ## How to apply (Supabase)
@@ -40,6 +42,7 @@ If the project uses Supabase, maintainers can run the same `psql` commands again
 - `scripts/005_add_last_read_to_room_members.sql` adds `last_read_at` used by the unread-count view.
 - `scripts/006_unread_view.sql` creates `public.user_room_unreads` view and grants `SELECT` to `public` for convenience; adjust privileges as needed.
 - `scripts/007_create_group_membership.sql` creates `public.group_membership` table for wallet-based group membership tracking.
+- `scripts/011_enhance_invites_for_group_join.sql` adds `max_uses` and `use_count` columns to `public.invites`, adds RLS policies for authenticated read/update, and creates the `increment_invite_use_count` SQL function for atomic usage tracking.
 - A development-only endpoint (`/api/rooms/seed-test`) was added that seeds a room for an authenticated user. It requires a valid Supabase session; do not enable any service-role or unauthenticated behavior in production without review.
 
 ## Including migrations in PRs


### PR DESCRIPTION
## Summary

Implements the full invite code flow for joining groups, closing #111.

- `POST /api/groups/:id/invite` — generates a UUID-based invite code for a group, with optional time-based (`expires_in`) and usage-based (`max_uses`) expiry
- `POST /api/groups/join` — validates an invite code and adds the authenticated user to the group's membership
- Migration `011` enhances the `invites` table with usage tracking and adds an atomic PostgreSQL RPC for incrementing use counts without race conditions

## What changed

### New files
| File | Purpose |
|---|---|
| `lib/groups/invite.ts` | Shared utility — code generation, expiry calculation, validation logic, atomic use_count increment |
| `app/api/groups/[id]/invite/route.ts` | `POST /api/groups/:id/invite` — generate invite code |
| `app/api/groups/join/route.ts` | `POST /api/groups/join` — join group via invite code |
| `scripts/011_enhance_invites_for_group_join.sql` | DB migration — adds `max_uses`, `use_count`, RLS policies, and `increment_invite_use_count` SQL function |

### Modified
- `scripts/MIGRATIONS_README.md` — documents migration 011 and psql apply command

## API reference

### Generate invite code
```
POST /api/groups/:id/invite
Authorization: session cookie (authenticated user, must be group creator or member)

Body (all optional):
{
  "expires_in": 86400,   // seconds until expiry (omit = no time limit)
  "max_uses": 10         // usage cap (omit = unlimited)
}

201 Created
{
  "success": true,
  "invite": {
    "code": "550e8400-e29b-41d4-a716-446655440000",
    "group_id": "room_...",
    "created_at": "2026-04-25T...",
    "expires_at": "2026-04-26T...",
    "max_uses": 10
  }
}
```

### Join via invite code
```
POST /api/groups/join
Authorization: session cookie (authenticated user)

Body:
{ "code": "550e8400-e29b-41d4-a716-446655440000" }

200 OK
{
  "success": true,
  "group": { "id": "room_...", "name": "..." },
  "membership": { "user_id": "...", "group_id": "...", "joined_at": "..." }
}

Error responses:
400 — missing/invalid code
401 — unauthenticated
403 — not a group member (invite generation only)
404 — code not found / group not found
410 — code expired (time or usage limit reached)
500 — server error
```

## DB migration

Apply after existing migrations:
```bash
psql "$DATABASE_URL" -f scripts/011_enhance_invites_for_group_join.sql
```

Changes to `public.invites`:
- Adds `max_uses INTEGER` (nullable, unlimited when null)
- Adds `use_count INTEGER NOT NULL DEFAULT 0`
- Adds RLS policy: authenticated users can read invites by code (required for join validation)
- Adds RLS policy: authenticated users can update invites (required for use_count increment)
- Creates `increment_invite_use_count(invite_code text)` as `SECURITY DEFINER` for atomic updates
- Adds indexes on `room_id` and `created_by`

## Acceptance criteria checklist

- [x] Generate a unique invite code for each group
- [x] Validate invite code before allowing a user to join
- [x] Support optional time-based expiration (`expires_in`)
- [x] Support optional usage-based expiration (`max_uses`)
- [x] Codes cannot be reused after expiration (time or usage limit)
- [x] Invite codes stored securely in DB with metadata (group ID, createdAt, expiresAt, max_uses, use_count)
- [x] Clear error messages for invalid/expired codes (400, 404, 410)
- [x] Successful validation adds user to group and updates membership records
- [x] UUID format for invite codes
- [x] Middleware-style validation extracted to `lib/groups/invite.ts`
- [x] Proper logging for join attempts (both success and failure)

