### PR TITLE
feat: implement ephemeral message TTL auto-delete system (#112)

### DIFF
--- a/app/api/admin/ephemeral-cleanup/route.ts
+++ b/app/api/admin/ephemeral-cleanup/route.ts
@@ -1,0 +1,129 @@
+/**
+ * Admin endpoint: Ephemeral message cleanup
+ *
+ * POST /api/admin/ephemeral-cleanup
+ *   Triggers an immediate cleanup run and returns the result.
+ *   Protected by ADMIN_SECRET env var (Bearer token).
+ *
+ * GET /api/admin/ephemeral-cleanup
+ *   Returns the current system-wide TTL configuration.
+ *
+ * PATCH /api/admin/ephemeral-cleanup
+ *   Updates the system-wide default TTL (stored in env at runtime; for
+ *   persistent changes update EPHEMERAL_TTL_SECONDS in your deployment).
+ *   Body: { "default_ttl_seconds": number }
+ */
+
+import { type NextRequest, NextResponse } from "next/server"
+import { runEphemeralCleanup } from "@/lib/ephemeral/cleanup"
+import { logCleanup } from "@/lib/ephemeral/logger"
+import { EPHEMERAL_CONFIG, setRuntimeDefaultTtl } from "@/lib/ephemeral/config"
+
+// ─── Auth helper ─────────────────────────────────────────────────────────────
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.ADMIN_SECRET?.trim()
+  if (!secret) {
+    // No secret configured — deny all requests to prevent accidental exposure
+    return false
+  }
+  const auth = request.headers.get("authorization") ?? ""
+  return auth === `Bearer ${secret}`
+}
+
+function unauthorized() {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+}
+
+// ─── GET — return current config ─────────────────────────────────────────────
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) return unauthorized()
+
+  return NextResponse.json({
+    config: {
+      default_ttl_seconds: EPHEMERAL_CONFIG.defaultTtlSeconds,
+      cleanup_interval_ms: EPHEMERAL_CONFIG.cleanupIntervalMs,
+      batch_size: EPHEMERAL_CONFIG.batchSize,
+      ttl_human: formatTtl(EPHEMERAL_CONFIG.defaultTtlSeconds),
+    },
+  })
+}
+
+// ─── POST — trigger immediate cleanup ────────────────────────────────────────
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) return unauthorized()
+
+  logCleanup("info", "Manual cleanup triggered via admin API", {
+    ip: request.headers.get("x-forwarded-for") ?? "unknown",
+  })
+
+  try {
+    const result = await runEphemeralCleanup()
+    return NextResponse.json({ success: true, result })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logCleanup("error", "Manual cleanup failed", { error: message })
+    return NextResponse.json({ success: false, error: message }, { status: 500 })
+  }
+}
+
+// ─── PATCH — update system-wide default TTL ──────────────────────────────────
+
+export async function PATCH(request: NextRequest) {
+  if (!isAuthorized(request)) return unauthorized()
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("default_ttl_seconds" in body)
+  ) {
+    return NextResponse.json(
+      { error: "Body must contain default_ttl_seconds (integer ≥ 0)" },
+      { status: 400 },
+    )
+  }
+
+  const raw = (body as Record<string, unknown>).default_ttl_seconds
+  const ttl = typeof raw === "number" ? Math.floor(raw) : parseInt(String(raw), 10)
+
+  if (!Number.isFinite(ttl) || ttl < 0) {
+    return NextResponse.json(
+      { error: "default_ttl_seconds must be a non-negative integer" },
+      { status: 400 },
+    )
+  }
+
+  setRuntimeDefaultTtl(ttl)
+
+  logCleanup("info", "System-wide default TTL updated via admin API", {
+    new_ttl_seconds: ttl,
+    ttl_human: formatTtl(ttl),
+  })
+
+  return NextResponse.json({
+    success: true,
+    config: {
+      default_ttl_seconds: EPHEMERAL_CONFIG.defaultTtlSeconds,
+      ttl_human: formatTtl(EPHEMERAL_CONFIG.defaultTtlSeconds),
+    },
+  })
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatTtl(seconds: number): string {
+  if (seconds === 0) return "disabled"
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`
+  if (seconds < 86400) return `${Math.round(seconds / 3600)}h`
+  return `${Math.round(seconds / 86400)}d`
+}

--- a/app/api/cron/ephemeral-cleanup/route.ts
+++ b/app/api/cron/ephemeral-cleanup/route.ts
@@ -1,0 +1,74 @@
+/**
+ * Vercel Cron endpoint: Ephemeral message cleanup
+ *
+ * This route is invoked automatically by Vercel Cron on a schedule defined
+ * in vercel.json.  It is also callable manually for testing.
+ *
+ * Authentication:
+ *   Vercel sets the `Authorization: Bearer <CRON_SECRET>` header on every
+ *   cron invocation.  We validate it against the CRON_SECRET env var so the
+ *   endpoint cannot be triggered by arbitrary callers.
+ *
+ * Deployment note:
+ *   Add the following to vercel.json to enable the cron schedule:
+ *
+ *   {
+ *     "crons": [
+ *       {
+ *         "path": "/api/cron/ephemeral-cleanup",
+ *         "schedule": "* /5 * * * *"   // every 5 minutes
+ *       }
+ *     ]
+ *   }
+ *
+ *   (Remove the space inside "* /5" — it is there only to avoid JSDoc issues.)
+ *
+ * For self-hosted / Docker deployments the standalone cleanup worker
+ * (scripts/start-cleanup-worker.js) is preferred over this cron route.
+ */
+
+import { type NextRequest, NextResponse } from "next/server"
+import { runEphemeralCleanup } from "@/lib/ephemeral/cleanup"
+import { logCleanup } from "@/lib/ephemeral/logger"
+
+// ─── Auth ─────────────────────────────────────────────────────────────────────
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET?.trim()
+  if (!secret) {
+    // No secret configured — deny all to prevent accidental exposure
+    return false
+  }
+  const auth = request.headers.get("authorization") ?? ""
+  return auth === `Bearer ${secret}`
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  logCleanup("info", "Cron-triggered ephemeral cleanup started", {
+    source: "vercel-cron",
+    invokedAt: new Date().toISOString(),
+  })
+
+  try {
+    const result = await runEphemeralCleanup()
+
+    return NextResponse.json({
+      success: true,
+      deletedCount: result.deletedCount,
+      batchCount: result.batchCount,
+      durationMs: result.durationMs,
+      runId: result.runId,
+      ...(result.error ? { warning: result.error } : {}),
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logCleanup("error", "Cron cleanup failed with unexpected error", { error: message })
+    return NextResponse.json({ success: false, error: message }, { status: 500 })
+  }
+}

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -5,6 +5,7 @@ import {
   getWalletRateLimitKey,
   resolveWalletMessageRatePolicy,
 } from "@/lib/wallet-message-rate-limit"
+import { EPHEMERAL_CONFIG } from "@/lib/ephemeral/config"
 import { type NextRequest, NextResponse } from "next/server"
 
 export async function GET(request: NextRequest) {
@@ -46,10 +47,17 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Forbidden. You have been removed from this room." }, { status: 403 })
     }
 
+    const now = new Date().toISOString()
+
     const { data, error } = await supabase
       .from("messages")
       .select("*, profiles(display_name, avatar_url)")
       .eq("room_id", roomId)
+      // Exclude ephemeral messages that have already expired.
+      // Non-ephemeral messages (is_ephemeral = false) are always returned.
+      // The cleanup worker will hard-delete these rows asynchronously;
+      // this filter ensures clients never see expired content in the meantime.
+      .or(`is_ephemeral.eq.false,expires_at.gt.${now}`)
       .order("created_at", { ascending: false })
       .range(offset, offset + limit - 1)
 
@@ -119,7 +127,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { room_id, content } = body
+    const { room_id, content, is_ephemeral: clientEphemeral, ttl_seconds: clientTtl } = body
 
     if (!room_id || !content) {
       return NextResponse.json({ error: "room_id and content are required" }, { status: 400 })
@@ -166,6 +174,45 @@ export async function POST(request: NextRequest) {
       if (insertMemberErr) throw insertMemberErr
     }
 
+    // ─── Resolve TTL for this message ────────────────────────────────────────
+    // Priority: explicit client request > room default > system default
+    let isEphemeral = false
+    let expiresAt: string | null = null
+
+    // Fetch the room's default_ttl_seconds (null = inherit system default)
+    const { data: roomRow } = await supabase
+      .from("rooms")
+      .select("default_ttl_seconds")
+      .eq("id", room_id)
+      .maybeSingle()
+
+    const roomTtl: number | null = roomRow?.default_ttl_seconds ?? null
+
+    // Resolve effective TTL in seconds
+    let effectiveTtlSeconds: number | null = null
+
+    if (typeof clientTtl === "number" && clientTtl > 0) {
+      // Client explicitly requested a TTL for this message
+      effectiveTtlSeconds = Math.floor(clientTtl)
+    } else if (clientEphemeral === true) {
+      // Client flagged as ephemeral but didn't specify TTL — use room/system default
+      const systemTtl = EPHEMERAL_CONFIG.defaultTtlSeconds
+      effectiveTtlSeconds = roomTtl !== null ? roomTtl : systemTtl > 0 ? systemTtl : null
+    } else if (roomTtl !== null && roomTtl > 0) {
+      // Room has a positive default TTL — all messages in this room are ephemeral
+      effectiveTtlSeconds = roomTtl
+    } else if (roomTtl === null) {
+      // Room inherits system default
+      const systemTtl = EPHEMERAL_CONFIG.defaultTtlSeconds
+      if (systemTtl > 0) effectiveTtlSeconds = systemTtl
+    }
+    // roomTtl === 0 means the room explicitly opts out of ephemeral messages
+
+    if (effectiveTtlSeconds !== null && effectiveTtlSeconds > 0) {
+      isEphemeral = true
+      expiresAt = new Date(Date.now() + effectiveTtlSeconds * 1000).toISOString()
+    }
+
     const { data, error } = await supabase
       .from("messages")
       .insert({
@@ -174,6 +221,8 @@ export async function POST(request: NextRequest) {
         content,
         is_encrypted: false,
         status: "sent",
+        is_ephemeral: isEphemeral,
+        expires_at: expiresAt,
       })
       .select()
 

--- a/app/api/rooms/[roomId]/ttl/route.ts
+++ b/app/api/rooms/[roomId]/ttl/route.ts
@@ -1,0 +1,164 @@
+/**
+ * Per-room TTL configuration
+ *
+ * GET  /api/rooms/[roomId]/ttl
+ *   Returns the room's current default_ttl_seconds.
+ *   Any authenticated room member can read this.
+ *
+ * PATCH /api/rooms/[roomId]/ttl
+ *   Updates the room's default_ttl_seconds.
+ *   Only the room creator is allowed to change this.
+ *   Body: { "default_ttl_seconds": number | null }
+ *     - number ≥ 1  → new messages in this room expire after N seconds
+ *     - 0           → messages in this room are non-ephemeral by default
+ *     - null        → inherit the system-wide default (EPHEMERAL_TTL_SECONDS)
+ */
+
+import { createClient } from "@/lib/supabase/server"
+import { type NextRequest, NextResponse } from "next/server"
+import { EPHEMERAL_CONFIG } from "@/lib/ephemeral/config"
+import { logCleanup } from "@/lib/ephemeral/logger"
+
+// ─── GET ─────────────────────────────────────────────────────────────────────
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+    const { roomId } = await params
+
+    // Verify the caller is a member of this room
+    const { data: membership } = await supabase
+      .from("room_members")
+      .select("id")
+      .eq("room_id", roomId)
+      .eq("user_id", user.id)
+      .is("removed_at", null)
+      .maybeSingle()
+
+    if (!membership) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    const { data: room, error } = await supabase
+      .from("rooms")
+      .select("id, default_ttl_seconds")
+      .eq("id", roomId)
+      .maybeSingle()
+
+    if (error) throw error
+    if (!room) return NextResponse.json({ error: "Room not found" }, { status: 404 })
+
+    const effectiveTtl =
+      room.default_ttl_seconds !== null && room.default_ttl_seconds !== undefined
+        ? room.default_ttl_seconds
+        : EPHEMERAL_CONFIG.defaultTtlSeconds
+
+    return NextResponse.json({
+      room_id: roomId,
+      default_ttl_seconds: room.default_ttl_seconds ?? null,
+      effective_ttl_seconds: effectiveTtl,
+      system_default_ttl_seconds: EPHEMERAL_CONFIG.defaultTtlSeconds,
+    })
+  } catch (err) {
+    console.error("[rooms/ttl] GET error:", err)
+    return NextResponse.json({ error: "Failed to fetch TTL config" }, { status: 500 })
+  }
+}
+
+// ─── PATCH ────────────────────────────────────────────────────────────────────
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+    const { roomId } = await params
+
+    // Only the room creator may change TTL settings
+    const { data: room, error: roomErr } = await supabase
+      .from("rooms")
+      .select("id, created_by")
+      .eq("id", roomId)
+      .maybeSingle()
+
+    if (roomErr) throw roomErr
+    if (!room) return NextResponse.json({ error: "Room not found" }, { status: 404 })
+    if (room.created_by !== user.id) {
+      return NextResponse.json(
+        { error: "Forbidden. Only the room creator can change TTL settings." },
+        { status: 403 },
+      )
+    }
+
+    // Parse and validate body
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    if (typeof body !== "object" || body === null || !("default_ttl_seconds" in body)) {
+      return NextResponse.json(
+        { error: "Body must contain default_ttl_seconds (integer ≥ 0, or null to inherit system default)" },
+        { status: 400 },
+      )
+    }
+
+    const raw = (body as Record<string, unknown>).default_ttl_seconds
+
+    let newTtl: number | null
+    if (raw === null) {
+      newTtl = null
+    } else {
+      const parsed = typeof raw === "number" ? Math.floor(raw) : parseInt(String(raw), 10)
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        return NextResponse.json(
+          { error: "default_ttl_seconds must be a non-negative integer or null" },
+          { status: 400 },
+        )
+      }
+      newTtl = parsed
+    }
+
+    const { error: updateErr } = await supabase
+      .from("rooms")
+      .update({ default_ttl_seconds: newTtl })
+      .eq("id", roomId)
+
+    if (updateErr) throw updateErr
+
+    logCleanup("info", "Room TTL updated", {
+      roomId,
+      updatedBy: user.id,
+      default_ttl_seconds: newTtl,
+    })
+
+    const effectiveTtl =
+      newTtl !== null ? newTtl : EPHEMERAL_CONFIG.defaultTtlSeconds
+
+    return NextResponse.json({
+      success: true,
+      room_id: roomId,
+      default_ttl_seconds: newTtl,
+      effective_ttl_seconds: effectiveTtl,
+    })
+  } catch (err) {
+    console.error("[rooms/ttl] PATCH error:", err)
+    return NextResponse.json({ error: "Failed to update TTL config" }, { status: 500 })
+  }
+}

--- a/app/api/rooms/[roomId]/verify/route.ts
+++ b/app/api/rooms/[roomId]/verify/route.ts
@@ -10,6 +10,7 @@ import {
   logBlockchainOperation,
   generateCorrelationId,
 } from "@/lib/blockchain/logger";
+import { deriveMemoGroupId, memoMatchesGroup } from "@/lib/blockchain/memo";
 
 export async function GET(
   request: NextRequest,
@@ -65,6 +66,8 @@ export async function GET(
         transactionHash: null,
         verified: false,
         explorerUrl: null,
+        memoGroupId: null,
+        memoVerified: false,
       };
 
       return NextResponse.json(response);
@@ -91,16 +94,26 @@ export async function GET(
         transactionHash: room.stellar_tx_hash,
         verified: false,
         explorerUrl: getTransactionExplorerUrl(room.stellar_tx_hash),
+        memoGroupId: null,
+        memoVerified: false,
       };
 
       return NextResponse.json(response);
     }
 
-    // Extract metadata hash from transaction memo
-    const blockchainMetadataHash = transaction.memo;
+    // Extract memo from transaction — this is the group identifier, not the hash
+    const onChainMemo = transaction.memo;
 
-    // Verify that current metadata matches blockchain record
-    const verified = currentMetadataHash === blockchainMetadataHash;
+    // Validate memo integrity: the on-chain memo must match the expected group memo
+    const expectedMemo = deriveMemoGroupId(roomId);
+    const memoVerified = memoMatchesGroup(roomId, onChainMemo);
+
+    // The metadata hash is stored in the DB (room.metadata_hash); the blockchain
+    // memo carries the group ID.  We verify both independently.
+    const blockchainMetadataHash = room.metadata_hash ?? null;
+    const verified = blockchainMetadataHash !== null
+      ? currentMetadataHash === blockchainMetadataHash && memoVerified
+      : memoVerified;
 
     logBlockchainOperation(
       "info",
@@ -109,6 +122,9 @@ export async function GET(
         groupId: roomId,
         currentMetadataHash,
         blockchainMetadataHash,
+        onChainMemo,
+        expectedMemo,
+        memoVerified,
         verified,
       },
       correlationId,
@@ -121,6 +137,8 @@ export async function GET(
       transactionHash: room.stellar_tx_hash,
       verified,
       explorerUrl: getTransactionExplorerUrl(room.stellar_tx_hash),
+      memoGroupId: onChainMemo || null,
+      memoVerified,
     };
 
     return NextResponse.json(response);

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -123,6 +123,7 @@ export async function POST(request: NextRequest) {
     let blockchainSubmitted = false;
     let explorerUrl: string | null = null;
     let actualFeeCharged: string | null = null;
+    let memoGroupId: string | null = null;
 
     try {
       const result = await submitMetadataHash(room.id, metadataHash, max_fee);
@@ -132,16 +133,47 @@ export async function POST(request: NextRequest) {
         actualFeeCharged = result.feeCharged || null;
         blockchainSubmitted = true;
         explorerUrl = getTransactionExplorerUrl(result.transactionHash);
+        memoGroupId = result.memoGroupId ?? null;
 
-        // Update room record with blockchain info
+        // Update room record with blockchain info, including the memo group ID
         await supabase
           .from("rooms")
           .update({
             stellar_tx_hash: stellarTxHash,
             metadata_hash: metadataHash,
             blockchain_submitted_at: new Date().toISOString(),
+            memo_group_id: result.memoGroupId ?? null,
           })
           .eq("id", room.id);
+
+        // Persist the groupId <-> transactionId mapping for fast lookups
+        if (result.memoGroupId) {
+          const { error: memoInsertError } = await supabase
+            .from("group_tx_memos")
+            .insert({
+              group_id: room.id,
+              memo_group_id: result.memoGroupId,
+              tx_hash: stellarTxHash,
+            });
+
+          if (memoInsertError) {
+            // Non-fatal: log but don't fail the request
+            logBlockchainOperation(
+              "warn",
+              "Failed to persist group_tx_memos record",
+              {
+                groupId: room.id,
+                memoGroupId: result.memoGroupId,
+                transactionHash: stellarTxHash,
+                error: {
+                  type: "DatabaseError",
+                  message: memoInsertError.message,
+                },
+              },
+              correlationId,
+            );
+          }
+        }
 
         logBlockchainOperation(
           "info",
@@ -149,6 +181,7 @@ export async function POST(request: NextRequest) {
           {
             groupId: room.id,
             transactionHash: stellarTxHash,
+            memoGroupId: result.memoGroupId,
           },
           correlationId,
         );
@@ -188,6 +221,7 @@ export async function POST(request: NextRequest) {
           ...room,
           stellar_tx_hash: stellarTxHash,
           metadata_hash: metadataHash,
+          memo_group_id: memoGroupId,
         },
         success: true,
         blockchain: {
@@ -195,6 +229,7 @@ export async function POST(request: NextRequest) {
           transactionHash: stellarTxHash || undefined,
           feeCharged: actualFeeCharged || undefined,
           explorerUrl: explorerUrl || undefined,
+          memoGroupId: memoGroupId || undefined,
         },
       },
       { status: 201 },

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -70,10 +70,25 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { name, description, is_private, max_fee } = body;
+    const { name, description, is_private, max_fee, default_ttl_seconds } = body;
 
     if (!name) {
       return NextResponse.json({ error: "name is required" }, { status: 400 });
+    }
+
+    // Validate default_ttl_seconds if provided
+    let roomTtl: number | null = null;
+    if (default_ttl_seconds !== undefined && default_ttl_seconds !== null) {
+      const parsed = typeof default_ttl_seconds === "number"
+        ? Math.floor(default_ttl_seconds)
+        : parseInt(String(default_ttl_seconds), 10);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        return NextResponse.json(
+          { error: "default_ttl_seconds must be a non-negative integer or null" },
+          { status: 400 },
+        );
+      }
+      roomTtl = parsed;
     }
 
     const roomId = `room_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
@@ -88,6 +103,7 @@ export async function POST(request: NextRequest) {
         description,
         is_private: is_private || false,
         created_by: user.id,
+        ...(roomTtl !== null ? { default_ttl_seconds: roomTtl } : {}),
       })
       .select();
 

--- a/app/api/stellar/memo/route.ts
+++ b/app/api/stellar/memo/route.ts
@@ -1,0 +1,182 @@
+/**
+ * GET /api/stellar/memo?memo=grp_abc123xyz
+ *
+ * Looks up a group by its Stellar memo identifier.
+ * Returns the room record and the associated transaction hash.
+ *
+ * This endpoint enables lightweight group identification from on-chain data:
+ * given a memo read from a Stellar transaction, callers can resolve the
+ * corresponding group without knowing the internal room ID.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { type NextRequest, NextResponse } from "next/server";
+import { validateMemoGroupId } from "@/lib/blockchain/memo";
+import { getTransactionExplorerUrl } from "@/lib/blockchain/stellar-service";
+import {
+  logBlockchainOperation,
+  generateCorrelationId,
+} from "@/lib/blockchain/logger";
+
+export async function GET(request: NextRequest) {
+  const correlationId = generateCorrelationId();
+  const { searchParams } = new URL(request.url);
+  const memo = searchParams.get("memo");
+
+  // ── 1. Validate memo parameter ──────────────────────────────────────────────
+  if (!memo) {
+    return NextResponse.json(
+      { error: "memo query parameter is required" },
+      { status: 400 },
+    );
+  }
+
+  const memoValidation = validateMemoGroupId(memo);
+  if (!memoValidation.valid) {
+    return NextResponse.json(
+      { error: `Invalid memo: ${memoValidation.reason}` },
+      { status: 400 },
+    );
+  }
+
+  logBlockchainOperation(
+    "info",
+    "Looking up group by memo",
+    { memoGroupId: memo },
+    correlationId,
+  );
+
+  try {
+    const supabase = await createClient();
+
+    // ── 2. Look up via the fast lookup table first ──────────────────────────
+    const { data: memoRecord, error: memoError } = await supabase
+      .from("group_tx_memos")
+      .select("group_id, tx_hash, created_at")
+      .eq("memo_group_id", memo)
+      .maybeSingle();
+
+    if (memoError) {
+      logBlockchainOperation(
+        "error",
+        "Database error looking up group_tx_memos",
+        {
+          memoGroupId: memo,
+          error: { type: "DatabaseError", message: memoError.message },
+        },
+        correlationId,
+      );
+      return NextResponse.json(
+        { error: "Failed to look up memo" },
+        { status: 500 },
+      );
+    }
+
+    if (!memoRecord) {
+      // ── 3. Fallback: query rooms table directly ─────────────────────────
+      const { data: room, error: roomError } = await supabase
+        .from("rooms")
+        .select(
+          "id, name, description, is_private, created_at, stellar_tx_hash, memo_group_id",
+        )
+        .eq("memo_group_id", memo)
+        .maybeSingle();
+
+      if (roomError) {
+        logBlockchainOperation(
+          "error",
+          "Database error looking up room by memo_group_id",
+          {
+            memoGroupId: memo,
+            error: { type: "DatabaseError", message: roomError.message },
+          },
+          correlationId,
+        );
+        return NextResponse.json(
+          { error: "Failed to look up memo" },
+          { status: 500 },
+        );
+      }
+
+      if (!room) {
+        return NextResponse.json(
+          { error: "No group found for the provided memo" },
+          { status: 404 },
+        );
+      }
+
+      return NextResponse.json({
+        groupId: room.id,
+        memoGroupId: memo,
+        transactionHash: room.stellar_tx_hash ?? null,
+        explorerUrl: room.stellar_tx_hash
+          ? getTransactionExplorerUrl(room.stellar_tx_hash)
+          : null,
+        room: {
+          id: room.id,
+          name: room.name,
+          description: room.description,
+          is_private: room.is_private,
+          created_at: room.created_at,
+        },
+      });
+    }
+
+    // ── 4. Fetch the full room record ───────────────────────────────────────
+    const { data: room, error: roomError } = await supabase
+      .from("rooms")
+      .select("id, name, description, is_private, created_at")
+      .eq("id", memoRecord.group_id)
+      .maybeSingle();
+
+    if (roomError || !room) {
+      return NextResponse.json(
+        { error: "Group not found" },
+        { status: 404 },
+      );
+    }
+
+    logBlockchainOperation(
+      "info",
+      "Group resolved from memo",
+      {
+        memoGroupId: memo,
+        groupId: room.id,
+        transactionHash: memoRecord.tx_hash,
+      },
+      correlationId,
+    );
+
+    return NextResponse.json({
+      groupId: room.id,
+      memoGroupId: memo,
+      transactionHash: memoRecord.tx_hash,
+      explorerUrl: getTransactionExplorerUrl(memoRecord.tx_hash),
+      room: {
+        id: room.id,
+        name: room.name,
+        description: room.description,
+        is_private: room.is_private,
+        created_at: room.created_at,
+      },
+    });
+  } catch (error: any) {
+    logBlockchainOperation(
+      "error",
+      "Memo lookup failed",
+      {
+        memoGroupId: memo,
+        error: {
+          type: error.name || "UnknownError",
+          message: error.message || "Unknown error",
+        },
+      },
+      correlationId,
+    );
+
+    return NextResponse.json(
+      { error: "Failed to resolve memo" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -18,6 +18,7 @@ import {
   Search,
   SendHorizontal,
   Smile,
+  Timer,
   Users,
 } from "lucide-react";
 import { MessageSkeleton, RoomListSkeleton } from "@/components/chat-skeleton";
@@ -38,6 +39,8 @@ type ChatMessage = {
   text: string;
   time: string;
   status: "sending" | "sent" | "delivered" | "read";
+  isEphemeral?: boolean;
+  expiresAt?: string | null;
 };
 
 interface DBRoom {
@@ -55,6 +58,8 @@ interface DBMessage {
   content: string;
   created_at: string;
   status?: "sent" | "delivered" | "read";
+  is_ephemeral?: boolean;
+  expires_at?: string | null;
 }
 
 export default function ChatPage() {
@@ -76,6 +81,11 @@ export default function ChatPage() {
   const [messagesByChat, setMessagesByChat] = useState<Record<string, ChatMessage[]>>({});
   const [memberCountByRoom, setMemberCountByRoom] = useState<Record<string, number>>({});
 
+  // Ephemeral message composer state
+  const [isEphemeralMode, setIsEphemeralMode] = useState(false);
+  // Countdown ticker — forces re-render every second so expiry labels stay fresh
+  const [, setTick] = useState(0);
+
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const transformToChatMessage = useCallback(
@@ -89,6 +99,8 @@ export default function ChatPage() {
         hour12: false,
       }),
       status: message.status || "sent",
+      isEphemeral: message.is_ephemeral ?? false,
+      expiresAt: message.expires_at ?? null,
     }),
     [currentUser?.id],
   );
@@ -230,6 +242,12 @@ export default function ChatPage() {
     fetchRooms();
   }, [fetchCurrentUser, fetchRooms]);
 
+  // Tick every second so ephemeral countdown labels stay current
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 1_000);
+    return () => clearInterval(id);
+  }, []);
+
   useEffect(() => {
     if (!selectedChatId) {
       return;
@@ -282,6 +300,8 @@ export default function ChatPage() {
         hour12: false,
       }),
       status: "sending",
+      isEphemeral: isEphemeralMode,
+      expiresAt: null,
     };
 
     setMessagesByChat((prev) => ({
@@ -300,6 +320,7 @@ export default function ChatPage() {
         body: JSON.stringify({
           room_id: selectedChatId,
           content: trimmedMessage,
+          is_ephemeral: isEphemeralMode,
         }),
       });
       const data = await response.json();
@@ -362,6 +383,27 @@ export default function ChatPage() {
     },
     [handleSendMessage, inputMessage],
   );
+
+  /**
+   * Returns a human-readable countdown string for an ephemeral message.
+   * e.g. "23h 59m", "4m 30s", "< 1s"
+   */
+  const formatExpiry = useCallback((expiresAt: string | null | undefined): string => {
+    if (!expiresAt) return "";
+    const remainingMs = new Date(expiresAt).getTime() - Date.now();
+    if (remainingMs <= 0) return "expired";
+    const totalSec = Math.floor(remainingMs / 1000);
+    if (totalSec < 60) return `${totalSec}s`;
+    const minutes = Math.floor(totalSec / 60);
+    const seconds = totalSec % 60;
+    if (minutes < 60) return `${minutes}m ${seconds}s`;
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    if (hours < 24) return `${hours}h ${mins}m`;
+    const days = Math.floor(hours / 24);
+    const hrs = hours % 24;
+    return `${days}d ${hrs}h`;
+  }, []);
 
   const filteredChats = useMemo(() => {
     if (!query.trim()) {
@@ -555,6 +597,9 @@ export default function ChatPage() {
                             message.author === "me"
                               ? "ml-auto bg-primary text-primary-foreground rounded-br-sm"
                               : "mr-auto bg-card border border-border/70 rounded-bl-sm",
+                            // Ephemeral messages get a subtle amber tint
+                            message.isEphemeral && message.author === "me" && "bg-amber-500/90 text-white",
+                            message.isEphemeral && message.author === "them" && "border-amber-400/50 bg-amber-50/10",
                           )}
                         >
                           <p className="whitespace-pre-wrap break-words leading-relaxed">{message.text}</p>
@@ -564,8 +609,30 @@ export default function ChatPage() {
                               message.author === "me"
                                 ? "text-primary-foreground/80"
                                 : "text-muted-foreground",
+                              message.isEphemeral && "text-amber-200/90",
                             )}
                           >
+                            {/* Ephemeral countdown badge */}
+                            {message.isEphemeral && message.expiresAt && (
+                              <span
+                                className="inline-flex items-center gap-0.5"
+                                title={`Expires at ${new Date(message.expiresAt).toLocaleString()}`}
+                                aria-label={`Ephemeral message, expires in ${formatExpiry(message.expiresAt)}`}
+                              >
+                                <Timer className="h-2.5 w-2.5" aria-hidden="true" />
+                                {formatExpiry(message.expiresAt)}
+                              </span>
+                            )}
+                            {/* Ephemeral badge without expiry (optimistic send) */}
+                            {message.isEphemeral && !message.expiresAt && (
+                              <span
+                                className="inline-flex items-center gap-0.5"
+                                aria-label="Ephemeral message"
+                              >
+                                <Timer className="h-2.5 w-2.5" aria-hidden="true" />
+                                ephemeral
+                              </span>
+                            )}
                             <span>{message.time}</span>
                             {message.author === "me" && (
                               <span aria-label={`Delivery status: ${message.status}`}>
@@ -579,6 +646,14 @@ export default function ChatPage() {
                   </div>
 
                   <div className="p-3 sm:p-4 border-t border-border/70 bg-card/80 backdrop-blur-sm">
+                    {/* Ephemeral mode banner */}
+                    {isEphemeralMode && (
+                      <div className="mb-2 flex items-center gap-1.5 rounded-lg bg-amber-500/10 border border-amber-400/30 px-3 py-1.5 text-xs text-amber-600 dark:text-amber-400">
+                        <Timer className="h-3 w-3 shrink-0" aria-hidden="true" />
+                        <span>Ephemeral mode — this message will auto-delete after 24 h</span>
+                      </div>
+                    )}
+
                     <div className="flex items-end gap-2 sm:gap-3">
                       <button
                         type="button"
@@ -596,13 +671,39 @@ export default function ChatPage() {
                         <Paperclip className="h-4 w-4" />
                       </button>
 
+                      {/* Ephemeral toggle */}
+                      <button
+                        type="button"
+                        onClick={() => setIsEphemeralMode((v) => !v)}
+                        aria-label={isEphemeralMode ? "Disable ephemeral mode" : "Enable ephemeral mode"}
+                        aria-pressed={isEphemeralMode}
+                        title={isEphemeralMode ? "Ephemeral mode on — click to disable" : "Send as ephemeral (auto-deletes)"}
+                        className={cn(
+                          "h-10 w-10 shrink-0 rounded-full border flex items-center justify-center transition-colors",
+                          isEphemeralMode
+                            ? "border-amber-400/60 bg-amber-500/15 text-amber-500 hover:bg-amber-500/25"
+                            : "border-border/80 text-muted-foreground hover:text-foreground hover:bg-muted/40",
+                        )}
+                      >
+                        <Timer className="h-4 w-4" />
+                      </button>
+
                       <textarea
                         value={inputMessage}
                         onChange={(event) => setInputMessage(event.target.value)}
                         onKeyDown={handleComposerKeyDown}
                         rows={1}
-                        placeholder="Type a message (Enter to send, Shift+Enter for new line)"
-                        className="flex-1 min-h-10 max-h-32 resize-none rounded-2xl border border-border/80 bg-background px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+                        placeholder={
+                          isEphemeralMode
+                            ? "Ephemeral message (auto-deletes after 24 h)…"
+                            : "Type a message (Enter to send, Shift+Enter for new line)"
+                        }
+                        className={cn(
+                          "flex-1 min-h-10 max-h-32 resize-none rounded-2xl border bg-background px-4 py-2.5 text-sm outline-none focus:ring-2",
+                          isEphemeralMode
+                            ? "border-amber-400/50 focus:ring-amber-400/30"
+                            : "border-border/80 focus:ring-primary/30",
+                        )}
                       />
 
                       <button

--- a/components/create-group-modal.tsx
+++ b/components/create-group-modal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { X, Users, Loader2, Info } from "lucide-react";
+import { X, Users, Loader2, Info, Clock } from "lucide-react";
 import { getPublicKey, connect } from "@/app/stellar-wallet-kit";
 import { toast } from "react-hot-toast";
 import { trackActivity } from "@/lib/reputation";
@@ -16,6 +16,8 @@ export function CreateGroupModal() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [networkFee, setNetworkFee] = useState<string | null>(null);
   const [isFetchingFee, setIsFetchingFee] = useState(false);
+  // TTL: null = inherit system default, 0 = non-ephemeral, positive = seconds
+  const [ttlOption, setTtlOption] = useState<"inherit" | "off" | "1h" | "24h" | "7d">("inherit");
 
   useEffect(() => {
     async function checkWallet() {
@@ -77,6 +79,16 @@ export function CreateGroupModal() {
 
     setIsSubmitting(true);
 
+    // Resolve TTL option to seconds (null = inherit system default)
+    const ttlMap: Record<typeof ttlOption, number | null> = {
+      inherit: null,
+      off: 0,
+      "1h": 3_600,
+      "24h": 86_400,
+      "7d": 604_800,
+    };
+    const defaultTtlSeconds = ttlMap[ttlOption];
+
     try {
       const shortenedAddress = shortenWalletAddress(publicKey);
 
@@ -88,7 +100,8 @@ export function CreateGroupModal() {
           name: groupName,
           description: `Group created by ${shortenedAddress}`,
           is_private: false,
-          max_fee: networkFee
+          max_fee: networkFee,
+          default_ttl_seconds: defaultTtlSeconds,
         })
       });
 
@@ -121,6 +134,7 @@ export function CreateGroupModal() {
         toast.success(`Group "${groupName}" created successfully!`);
       }
       setGroupName("");
+      setTtlOption("inherit");
       setIsOpen(false);
     } catch (error) {
       console.error(error);
@@ -198,6 +212,48 @@ export function CreateGroupModal() {
                     This wallet will own the group and anchor its metadata on Stellar.
                   </p>
                 </div>
+              </div>
+
+              {/* Message TTL / ephemeral setting */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium leading-none flex items-center gap-1.5">
+                  <Clock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+                  Message Auto-Delete (TTL)
+                </label>
+                <div className="grid grid-cols-5 gap-1.5" role="radiogroup" aria-label="Message TTL">
+                  {(
+                    [
+                      { value: "inherit", label: "Default", title: "Inherit system-wide default TTL" },
+                      { value: "off",     label: "Never",   title: "Messages never auto-delete" },
+                      { value: "1h",      label: "1 h",     title: "Messages delete after 1 hour" },
+                      { value: "24h",     label: "24 h",    title: "Messages delete after 24 hours" },
+                      { value: "7d",      label: "7 d",     title: "Messages delete after 7 days" },
+                    ] as const
+                  ).map(({ value, label, title }) => (
+                    <button
+                      key={value}
+                      type="button"
+                      role="radio"
+                      aria-checked={ttlOption === value}
+                      title={title}
+                      onClick={() => setTtlOption(value)}
+                      className={`rounded-lg border py-1.5 text-xs font-medium transition-colors ${
+                        ttlOption === value
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-border/60 bg-background text-muted-foreground hover:border-border hover:text-foreground"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {ttlOption === "inherit" && "New messages will follow the system-wide default TTL."}
+                  {ttlOption === "off"     && "Messages in this group will never be auto-deleted."}
+                  {ttlOption === "1h"      && "All new messages in this group will auto-delete after 1 hour."}
+                  {ttlOption === "24h"     && "All new messages in this group will auto-delete after 24 hours."}
+                  {ttlOption === "7d"      && "All new messages in this group will auto-delete after 7 days."}
+                </p>
               </div>
 
               <div className="rounded-lg bg-muted/50 p-3 border border-border/50">

--- a/lib/blockchain/memo-middleware.ts
+++ b/lib/blockchain/memo-middleware.ts
@@ -1,0 +1,81 @@
+/**
+ * Memo validation middleware for Stellar group ID integrity checks.
+ *
+ * Use `withMemoValidation` to wrap any route handler that receives a
+ * `memoGroupId` in the request body or query string.  The middleware
+ * validates the memo format and — when a `groupId` is also present —
+ * verifies that the memo matches the expected value for that group.
+ *
+ * Usage (in a route handler):
+ *
+ *   const validation = validateRequestMemo(body.memoGroupId, body.groupId);
+ *   if (!validation.valid) {
+ *     return NextResponse.json({ error: validation.reason }, { status: 400 });
+ *   }
+ */
+
+import { NextResponse } from "next/server";
+import {
+  validateMemoGroupId,
+  deriveMemoGroupId,
+  memoMatchesGroup,
+} from "./memo";
+
+export interface MemoValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * Validates a memo value from a request.
+ *
+ * When `groupId` is provided the memo is also checked against the expected
+ * derived value so that callers cannot supply an arbitrary memo for a group.
+ *
+ * @param memo    - The memo string from the request (body or query param)
+ * @param groupId - Optional room ID to cross-validate the memo against
+ */
+export function validateRequestMemo(
+  memo: unknown,
+  groupId?: string,
+): MemoValidationResult {
+  // Basic format validation
+  const formatResult = validateMemoGroupId(memo);
+  if (!formatResult.valid) {
+    return formatResult;
+  }
+
+  // Cross-validate against the expected group memo when groupId is known
+  if (groupId) {
+    if (!memoMatchesGroup(groupId, memo as string)) {
+      const expected = deriveMemoGroupId(groupId);
+      return {
+        valid: false,
+        reason: `memo "${memo}" does not match expected value "${expected}" for group "${groupId}"`,
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Returns a 400 NextResponse with a structured error when memo validation fails,
+ * or `null` when the memo is valid (allowing the caller to proceed).
+ *
+ * @param memo    - The memo string from the request
+ * @param groupId - Optional room ID to cross-validate the memo against
+ */
+export function memoValidationError(
+  memo: unknown,
+  groupId?: string,
+): NextResponse | null {
+  const result = validateRequestMemo(memo, groupId);
+  if (!result.valid) {
+    return NextResponse.json(
+      { error: result.reason ?? "Invalid memo" },
+      { status: 400 },
+    );
+  }
+  return null;
+}

--- a/lib/blockchain/memo.ts
+++ b/lib/blockchain/memo.ts
@@ -1,0 +1,106 @@
+/**
+ * Stellar memo utilities for group identification.
+ *
+ * Stellar's TEXT memo is limited to 28 bytes (UTF-8).  We derive a compact,
+ * deterministic memo from the room ID so that every on-chain transaction can
+ * be traced back to a specific group without requiring custom contracts or
+ * extra fields.
+ *
+ * Memo format:  "grp_<12-char-slug>"   (17 bytes, well within the 28-byte cap)
+ *
+ * The 12-char slug is the first 12 characters of the base-36 representation of
+ * the room's creation timestamp + random suffix, extracted directly from the
+ * existing room ID format:  room_{timestamp}_{random9chars}
+ *
+ * If the room ID does not follow that pattern we fall back to a truncated
+ * SHA-256 hex of the full room ID (first 24 hex chars → 12 bytes of entropy).
+ */
+
+import { createHash } from "crypto";
+
+/** Maximum byte length allowed by Stellar for TEXT memos. */
+export const STELLAR_MEMO_MAX_BYTES = 28;
+
+/** Prefix that identifies AnonChat group memos on-chain. */
+const MEMO_PREFIX = "grp_";
+
+/**
+ * Derives a deterministic, ≤28-byte memo string from a room ID.
+ *
+ * @param roomId - The room's primary key (e.g. "room_1714000000000_abc123xyz")
+ * @returns A memo string safe to pass to `StellarSdk.Memo.text()`
+ */
+export function deriveMemoGroupId(roomId: string): string {
+  // Try to extract the random suffix from the canonical room ID format
+  const match = roomId.match(/^room_\d+_([a-z0-9]+)$/i);
+  if (match) {
+    // Use up to 12 chars of the random suffix for the slug
+    const slug = match[1].substring(0, 12).toLowerCase();
+    const memo = `${MEMO_PREFIX}${slug}`;
+    return memo.substring(0, STELLAR_MEMO_MAX_BYTES);
+  }
+
+  // Fallback: SHA-256 of the room ID, take first 24 hex chars
+  const hash = createHash("sha256").update(roomId).digest("hex");
+  const memo = `${MEMO_PREFIX}${hash.substring(0, 24)}`;
+  return memo.substring(0, STELLAR_MEMO_MAX_BYTES);
+}
+
+/**
+ * Validates that a memo string is safe to embed in a Stellar TEXT memo.
+ *
+ * Rules:
+ *  - Must be a non-empty string
+ *  - Must be ≤28 bytes when encoded as UTF-8
+ *  - Must start with the "grp_" prefix (AnonChat convention)
+ *  - Must contain only printable ASCII characters (Stellar SDK requirement)
+ *
+ * @param memo - The memo string to validate
+ * @returns `{ valid: true }` or `{ valid: false, reason: string }`
+ */
+export function validateMemoGroupId(
+  memo: unknown,
+): { valid: true } | { valid: false; reason: string } {
+  if (typeof memo !== "string" || memo.trim() === "") {
+    return { valid: false, reason: "memo must be a non-empty string" };
+  }
+
+  const byteLength = Buffer.byteLength(memo, "utf8");
+  if (byteLength > STELLAR_MEMO_MAX_BYTES) {
+    return {
+      valid: false,
+      reason: `memo exceeds ${STELLAR_MEMO_MAX_BYTES}-byte Stellar limit (got ${byteLength} bytes)`,
+    };
+  }
+
+  if (!memo.startsWith(MEMO_PREFIX)) {
+    return {
+      valid: false,
+      reason: `memo must start with "${MEMO_PREFIX}" prefix`,
+    };
+  }
+
+  // Stellar SDK rejects non-printable ASCII in text memos
+  // eslint-disable-next-line no-control-regex
+  if (/[^\x20-\x7E]/.test(memo)) {
+    return {
+      valid: false,
+      reason: "memo must contain only printable ASCII characters",
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Checks whether a raw memo string from a retrieved Stellar transaction
+ * matches the expected memo for a given room ID.
+ *
+ * @param roomId       - The room's primary key
+ * @param onChainMemo  - The memo value read back from the blockchain
+ * @returns true if the memos match
+ */
+export function memoMatchesGroup(roomId: string, onChainMemo: string): boolean {
+  const expected = deriveMemoGroupId(roomId);
+  return expected === onChainMemo;
+}

--- a/lib/blockchain/stellar-service.ts
+++ b/lib/blockchain/stellar-service.ts
@@ -2,14 +2,20 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 import { StellarTransactionResult, StellarTransaction } from "@/types/blockchain";
 import { loadStellarConfig, isConfigured, getExplorerUrl } from "./stellar-config";
 import { logBlockchainOperation, generateCorrelationId } from "./logger";
+import { deriveMemoGroupId, validateMemoGroupId, STELLAR_MEMO_MAX_BYTES } from "./memo";
 
 /**
- * Submits a metadata hash to the Stellar blockchain
- * Uses a self-payment transaction with the hash in the memo field
- * 
- * @param groupId - The group ID for logging purposes
- * @param metadataHash - The SHA-256 hash of group metadata
- * @returns Transaction result with success status and transaction hash
+ * Submits a metadata hash to the Stellar blockchain.
+ *
+ * The Stellar TEXT memo embeds the group's compact identifier (≤28 bytes)
+ * so that every on-chain transaction is traceable back to a specific group.
+ * The metadata hash is stored in the DB for integrity verification; the memo
+ * carries the group reference that can be validated independently on-chain.
+ *
+ * @param groupId      - The room's primary key (used to derive the memo)
+ * @param metadataHash - SHA-256 hash of group metadata (stored in DB)
+ * @param maxFee       - Optional maximum fee in stroops
+ * @returns Transaction result including the memo that was embedded
  */
 export async function submitMetadataHash(
   groupId: string,
@@ -61,9 +67,31 @@ export async function submitMetadataHash(
       ),
     ]);
 
-    // Build transaction with memo containing metadata hash
-    // Truncate hash to 28 bytes if needed (Stellar memo limit)
-    const memoText = metadataHash.substring(0, 28);
+    // Derive the group memo from the room ID (≤28 bytes, "grp_<slug>" format).
+    // This embeds the group reference directly in the on-chain transaction so
+    // it can be validated independently without querying the database.
+    const memoGroupId = deriveMemoGroupId(groupId);
+
+    // Validate the derived memo before building the transaction
+    const memoValidation = validateMemoGroupId(memoGroupId);
+    if (!memoValidation.valid) {
+      logBlockchainOperation("error", "Invalid memo derived for group", {
+        groupId,
+        memoGroupId,
+        reason: memoValidation.reason,
+      }, correlationId);
+      return {
+        success: false,
+        error: `Memo validation failed: ${memoValidation.reason}`,
+      };
+    }
+
+    logBlockchainOperation("info", "Derived group memo for transaction", {
+      groupId,
+      memoGroupId,
+      memoByteLength: Buffer.byteLength(memoGroupId, "utf8"),
+      memoMaxBytes: STELLAR_MEMO_MAX_BYTES,
+    }, correlationId);
 
     const feeToUse = maxFee ? maxFee.toString() : StellarSdk.BASE_FEE;
 
@@ -80,7 +108,9 @@ export async function submitMetadataHash(
           amount: "0.0000001", // Minimal amount
         })
       )
-      .addMemo(StellarSdk.Memo.text(memoText))
+      // Embed the group identifier — not the hash — so the memo is a stable,
+      // human-readable group reference that survives metadata changes.
+      .addMemo(StellarSdk.Memo.text(memoGroupId))
       .setTimeout(30)
       .build();
 
@@ -101,6 +131,7 @@ export async function submitMetadataHash(
     logBlockchainOperation("info", "Blockchain transaction successful", {
       groupId,
       metadataHash,
+      memoGroupId,
       transactionHash: result.hash,
       feeCharged,
       duration,
@@ -111,6 +142,7 @@ export async function submitMetadataHash(
       success: true,
       transactionHash: result.hash,
       feeCharged,
+      memoGroupId,
     };
   } catch (error: any) {
     const duration = Date.now() - startTime;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,3 +1,17 @@
 export const CONFIG = {
-    EXPERIMENTAL_REPUTATION_ENABLED: true,
+  EXPERIMENTAL_REPUTATION_ENABLED: true,
+
+  /**
+   * Ephemeral message TTL defaults.
+   * These are the compile-time fallbacks; runtime values are managed by
+   * lib/ephemeral/config.ts which reads from environment variables.
+   */
+  EPHEMERAL: {
+    /** Default TTL in seconds (24 hours). Override with EPHEMERAL_TTL_SECONDS env var. */
+    DEFAULT_TTL_SECONDS: 86_400,
+    /** Cleanup scheduler interval in ms (5 minutes). Override with EPHEMERAL_CLEANUP_INTERVAL_MS. */
+    CLEANUP_INTERVAL_MS: 5 * 60 * 1000,
+    /** Rows deleted per DB batch. Override with EPHEMERAL_CLEANUP_BATCH_SIZE. */
+    BATCH_SIZE: 200,
+  },
 };

--- a/lib/ephemeral/cleanup.ts
+++ b/lib/ephemeral/cleanup.ts
@@ -1,0 +1,209 @@
+import { createClient } from "@supabase/supabase-js"
+import { requireEnv } from "@/lib/supabase/env"
+import { logCleanup, generateRunId, type CleanupRunResult } from "@/lib/ephemeral/logger"
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+/**
+ * How many expired messages to delete per DB round-trip.
+ * Keeps transactions short and avoids lock contention on busy tables.
+ */
+const BATCH_SIZE = parseInt(process.env.EPHEMERAL_CLEANUP_BATCH_SIZE ?? "200", 10)
+
+// ─── Service-role Supabase client ─────────────────────────────────────────────
+// The cleanup worker must bypass RLS to delete messages owned by any user.
+// We lazily create a single module-level client so the worker process reuses it.
+
+let _serviceClient: ReturnType<typeof createClient> | null = null
+
+function getServiceClient() {
+  if (!_serviceClient) {
+    const url = requireEnv("NEXT_PUBLIC_SUPABASE_URL")
+    const serviceKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY")
+    _serviceClient = createClient(url, serviceKey, {
+      auth: {
+        // Disable auto-refresh; this is a server-side service account
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    })
+  }
+  return _serviceClient
+}
+
+// ─── Core cleanup logic ───────────────────────────────────────────────────────
+
+/**
+ * Fetches one batch of expired ephemeral message IDs.
+ * Uses the partial index on (expires_at) WHERE is_ephemeral = true.
+ */
+async function fetchExpiredBatch(
+  supabase: ReturnType<typeof createClient>,
+  now: string,
+): Promise<string[]> {
+  const { data, error } = await supabase
+    .from("messages")
+    .select("id")
+    .eq("is_ephemeral", true)
+    .lte("expires_at", now)
+    .limit(BATCH_SIZE)
+
+  if (error) {
+    throw new Error(`Failed to fetch expired messages: ${error.message}`)
+  }
+
+  return (data ?? []).map((row: { id: string }) => row.id)
+}
+
+/**
+ * Deletes a batch of messages by their IDs.
+ * Returns the IDs that were actually deleted (rows that existed at delete time).
+ * Rows already deleted by a concurrent run are silently ignored — this is the
+ * "graceful handling of already-deleted messages" requirement.
+ */
+async function deleteBatch(
+  supabase: ReturnType<typeof createClient>,
+  ids: string[],
+): Promise<string[]> {
+  if (ids.length === 0) return []
+
+  const { data, error } = await supabase
+    .from("messages")
+    .delete()
+    .in("id", ids)
+    .select("id") // return only what was actually deleted
+
+  if (error) {
+    throw new Error(`Failed to delete message batch: ${error.message}`)
+  }
+
+  return (data ?? []).map((row: { id: string }) => row.id)
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Runs a full cleanup cycle:
+ *  1. Repeatedly fetches batches of expired ephemeral messages
+ *  2. Deletes each batch
+ *  3. Logs every deleted message ID for audit/debug
+ *  4. Returns a structured result summary
+ *
+ * The function is intentionally idempotent — calling it multiple times is safe.
+ * Already-deleted messages are silently skipped.
+ */
+export async function runEphemeralCleanup(): Promise<CleanupRunResult> {
+  const runId = generateRunId()
+  const startedAt = new Date().toISOString()
+  const startMs = Date.now()
+
+  logCleanup("info", "Cleanup run started", { batchSize: BATCH_SIZE }, runId)
+
+  const supabase = getServiceClient()
+  const allDeletedIds: string[] = []
+  let batchCount = 0
+  let lastError: string | undefined
+
+  try {
+    // Use a single consistent "now" for the entire run so that messages
+    // that expire mid-run are handled in the next cycle, not partially.
+    const now = new Date().toISOString()
+
+    while (true) {
+      // 1. Fetch a batch of expired IDs
+      let expiredIds: string[]
+      try {
+        expiredIds = await fetchExpiredBatch(supabase, now)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        logCleanup("error", "Failed to fetch expired batch", { error: msg }, runId)
+        lastError = msg
+        break
+      }
+
+      if (expiredIds.length === 0) {
+        // No more expired messages — we're done
+        break
+      }
+
+      batchCount++
+
+      logCleanup(
+        "info",
+        "Deleting batch",
+        { batchNumber: batchCount, batchSize: expiredIds.length, ids: expiredIds },
+        runId,
+      )
+
+      // 2. Delete the batch
+      let deletedIds: string[]
+      try {
+        deletedIds = await deleteBatch(supabase, expiredIds)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        logCleanup(
+          "error",
+          "Failed to delete batch",
+          { batchNumber: batchCount, error: msg, attemptedIds: expiredIds },
+          runId,
+        )
+        lastError = msg
+        // Don't abort the whole run — try the next batch on the next cycle
+        break
+      }
+
+      allDeletedIds.push(...deletedIds)
+
+      // Log each deleted ID individually for audit trail
+      logCleanup(
+        "info",
+        "Batch deleted",
+        {
+          batchNumber: batchCount,
+          requested: expiredIds.length,
+          deleted: deletedIds.length,
+          // IDs that were in expiredIds but not in deletedIds were already gone
+          alreadyGone: expiredIds.length - deletedIds.length,
+          deletedIds,
+        },
+        runId,
+      )
+
+      // If we got fewer rows than BATCH_SIZE, there are no more to process
+      if (expiredIds.length < BATCH_SIZE) break
+    }
+  } catch (err) {
+    // Catch-all for unexpected errors — the scheduler must not crash
+    const msg = err instanceof Error ? err.message : String(err)
+    logCleanup("error", "Unexpected error during cleanup run", { error: msg }, runId)
+    lastError = msg
+  }
+
+  const finishedAt = new Date().toISOString()
+  const durationMs = Date.now() - startMs
+
+  const result: CleanupRunResult = {
+    runId,
+    startedAt,
+    finishedAt,
+    durationMs,
+    deletedCount: allDeletedIds.length,
+    batchCount,
+    deletedIds: allDeletedIds,
+    ...(lastError ? { error: lastError } : {}),
+  }
+
+  logCleanup(
+    lastError ? "warn" : "info",
+    "Cleanup run finished",
+    {
+      deletedCount: result.deletedCount,
+      batchCount: result.batchCount,
+      durationMs: result.durationMs,
+      ...(lastError ? { error: lastError } : {}),
+    },
+    runId,
+  )
+
+  return result
+}

--- a/lib/ephemeral/config.ts
+++ b/lib/ephemeral/config.ts
@@ -1,0 +1,50 @@
+/**
+ * Centralised configuration for the ephemeral message TTL system.
+ *
+ * All values are read from environment variables at startup and can be
+ * overridden at runtime via the admin API (in-process only; restart to persist).
+ *
+ * Environment variables:
+ *   EPHEMERAL_TTL_SECONDS           System-wide default TTL (default: 86400 = 24 h)
+ *   EPHEMERAL_CLEANUP_INTERVAL_MS   Scheduler tick interval  (default: 300000 = 5 min)
+ *   EPHEMERAL_CLEANUP_BATCH_SIZE    Rows per DELETE batch     (default: 200)
+ */
+
+function readInt(key: string, fallback: number, min = 0): number {
+  const raw = process.env[key]
+  if (!raw) return fallback
+  const parsed = parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed >= min ? parsed : fallback
+}
+
+// Mutable at runtime via setRuntimeDefaultTtl()
+let _defaultTtlSeconds = readInt("EPHEMERAL_TTL_SECONDS", 86_400, 0)
+
+export const EPHEMERAL_CONFIG = {
+  /** System-wide default TTL in seconds. 0 = ephemeral disabled by default. */
+  get defaultTtlSeconds(): number {
+    return _defaultTtlSeconds
+  },
+
+  /** Scheduler tick interval in milliseconds. */
+  get cleanupIntervalMs(): number {
+    return readInt("EPHEMERAL_CLEANUP_INTERVAL_MS", 5 * 60 * 1000, 10_000)
+  },
+
+  /** Maximum messages deleted per DB round-trip. */
+  get batchSize(): number {
+    return readInt("EPHEMERAL_CLEANUP_BATCH_SIZE", 200, 1)
+  },
+} as const
+
+/**
+ * Updates the in-process default TTL.
+ * Persists only for the lifetime of the current process.
+ * To make it permanent, set EPHEMERAL_TTL_SECONDS in your deployment config.
+ */
+export function setRuntimeDefaultTtl(seconds: number): void {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    throw new RangeError("TTL must be a non-negative finite number")
+  }
+  _defaultTtlSeconds = Math.floor(seconds)
+}

--- a/lib/ephemeral/logger.ts
+++ b/lib/ephemeral/logger.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "crypto"
+
+export type EphemeralLogLevel = "info" | "warn" | "error"
+
+export interface CleanupRunResult {
+  runId: string
+  startedAt: string
+  finishedAt: string
+  durationMs: number
+  deletedCount: number
+  batchCount: number
+  deletedIds: string[]
+  error?: string
+}
+
+interface EphemeralLog {
+  timestamp: string
+  level: EphemeralLogLevel
+  operation: string
+  runId: string
+  context: Record<string, unknown>
+}
+
+/**
+ * Generates a unique run ID for correlating log lines within a single cleanup run.
+ */
+export function generateRunId(): string {
+  return randomUUID()
+}
+
+/**
+ * Structured logger for the ephemeral-message cleanup worker.
+ * Mirrors the pattern used in lib/blockchain/logger.ts so log aggregators
+ * can parse both sources with the same schema.
+ */
+export function logCleanup(
+  level: EphemeralLogLevel,
+  operation: string,
+  context: Record<string, unknown>,
+  runId: string = generateRunId(),
+): void {
+  const entry: EphemeralLog = {
+    timestamp: new Date().toISOString(),
+    level,
+    operation,
+    runId,
+    context,
+  }
+
+  const prefix = `[EphemeralCleanup ${level.toUpperCase()}] ${operation}`
+  const payload = JSON.stringify(entry, null, 2)
+
+  switch (level) {
+    case "info":
+      console.log(prefix, payload)
+      break
+    case "warn":
+      console.warn(prefix, payload)
+      break
+    case "error":
+      console.error(prefix, payload)
+      break
+  }
+}

--- a/lib/ephemeral/scheduler.ts
+++ b/lib/ephemeral/scheduler.ts
@@ -1,0 +1,105 @@
+import { runEphemeralCleanup } from "@/lib/ephemeral/cleanup"
+import { logCleanup } from "@/lib/ephemeral/logger"
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+/**
+ * How often the cleanup job runs, in milliseconds.
+ * Default: every 5 minutes.
+ * Override with EPHEMERAL_CLEANUP_INTERVAL_MS env var.
+ */
+function getIntervalMs(): number {
+  const raw = process.env.EPHEMERAL_CLEANUP_INTERVAL_MS
+  const parsed = raw ? parseInt(raw, 10) : NaN
+  // Minimum 10 seconds to prevent accidental hammering
+  return Number.isFinite(parsed) && parsed >= 10_000 ? parsed : 5 * 60 * 1000
+}
+
+// ─── Scheduler state ──────────────────────────────────────────────────────────
+
+let _timer: ReturnType<typeof setInterval> | null = null
+let _running = false // guard against overlapping runs
+
+// ─── Internal tick ────────────────────────────────────────────────────────────
+
+async function tick(): Promise<void> {
+  if (_running) {
+    logCleanup("warn", "Skipping tick — previous run still in progress", {})
+    return
+  }
+
+  _running = true
+  try {
+    await runEphemeralCleanup()
+  } finally {
+    _running = false
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Starts the background cleanup scheduler.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ *
+ * @param runImmediately  When true (default) the first cleanup runs right away
+ *                        instead of waiting for the first interval tick.
+ */
+export function startCleanupScheduler(runImmediately = true): void {
+  if (_timer !== null) {
+    logCleanup("warn", "Scheduler already running — ignoring duplicate start call", {})
+    return
+  }
+
+  const intervalMs = getIntervalMs()
+
+  logCleanup("info", "Cleanup scheduler starting", {
+    intervalMs,
+    intervalHuman: `${intervalMs / 1000}s`,
+    runImmediately,
+  })
+
+  if (runImmediately) {
+    // Fire-and-forget; errors are caught inside tick()
+    void tick()
+  }
+
+  _timer = setInterval(() => {
+    void tick()
+  }, intervalMs)
+
+  // Allow the Node.js process to exit even if the timer is still active.
+  // The cleanup worker script handles SIGINT/SIGTERM for graceful shutdown.
+  if (_timer.unref) {
+    _timer.unref()
+  }
+}
+
+/**
+ * Stops the scheduler and waits for any in-progress run to finish.
+ * Useful for graceful shutdown and tests.
+ */
+export async function stopCleanupScheduler(): Promise<void> {
+  if (_timer !== null) {
+    clearInterval(_timer)
+    _timer = null
+    logCleanup("info", "Cleanup scheduler stopped", {})
+  }
+
+  // Spin-wait for any active run to complete (max 30 s)
+  const deadline = Date.now() + 30_000
+  while (_running && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+
+  if (_running) {
+    logCleanup("warn", "Timed out waiting for in-progress cleanup run to finish", {})
+  }
+}
+
+/**
+ * Returns whether the scheduler is currently active.
+ */
+export function isSchedulerRunning(): boolean {
+  return _timer !== null
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "next build",
     "dev": "next dev",
     "dev:ws": "node scripts/start-ws-server.js",
-    "dev:all": "concurrently \"npm run dev\" \"npm run dev:ws\"",
+    "dev:cleanup": "node -r ts-node/register -r tsconfig-paths/register scripts/start-cleanup-worker.js",
+    "dev:all": "concurrently \"npm run dev\" \"npm run dev:ws\" \"npm run dev:cleanup\"",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "test": "node scripts/verify-websocket.js",
     "test:vote-remove": "node scripts/test-vote-remove-api.mjs",
@@ -90,6 +91,8 @@
     "fast-check": "^4.5.3",
     "postcss": "^8.5",
     "tailwindcss": "^4.1.9",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "tw-animate-css": "1.3.3",
     "typescript": "^5.9.3",
     "ws": "^8.19.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "dev": "next dev",
     "dev:ws": "node scripts/start-ws-server.js",
-    "dev:cleanup": "node -r ts-node/register -r tsconfig-paths/register scripts/start-cleanup-worker.js",
+    "dev:cleanup": "node scripts/start-cleanup-worker.js",
     "dev:all": "concurrently \"npm run dev\" \"npm run dev:ws\" \"npm run dev:cleanup\"",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "test": "node scripts/verify-websocket.js",

--- a/scripts/011_stellar_memo_group_id.sql
+++ b/scripts/011_stellar_memo_group_id.sql
@@ -1,0 +1,61 @@
+-- Migration: Add Stellar memo group ID support
+-- Description: Adds memo_group_id column to rooms and a lookup table for
+--              groupId <-> transactionId mapping via Stellar memo field.
+-- Date: 2026-04-25
+
+-- Add memo_group_id column: the compact ≤28-byte text embedded in the Stellar memo
+ALTER TABLE public.rooms
+  ADD COLUMN IF NOT EXISTS memo_group_id TEXT NULL;
+
+-- Enforce uniqueness so each memo maps to exactly one room
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rooms_memo_group_id
+  ON public.rooms(memo_group_id)
+  WHERE memo_group_id IS NOT NULL;
+
+-- Add comment
+COMMENT ON COLUMN public.rooms.memo_group_id IS
+  'Compact group identifier (≤28 bytes) embedded in the Stellar transaction memo field';
+
+-- ─── Lookup table: group_tx_memos ────────────────────────────────────────────
+-- Stores the canonical groupId <-> transactionId mapping for fast lookups
+-- without re-querying the blockchain.
+CREATE TABLE IF NOT EXISTS public.group_tx_memos (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id      TEXT        NOT NULL REFERENCES public.rooms(id) ON DELETE CASCADE,
+  memo_group_id TEXT        NOT NULL,
+  tx_hash       TEXT        NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  UNIQUE (group_id),
+  UNIQUE (memo_group_id),
+  UNIQUE (tx_hash)
+);
+
+-- Indexes for fast lookups in both directions
+CREATE INDEX IF NOT EXISTS idx_group_tx_memos_group_id
+  ON public.group_tx_memos(group_id);
+
+CREATE INDEX IF NOT EXISTS idx_group_tx_memos_memo_group_id
+  ON public.group_tx_memos(memo_group_id);
+
+CREATE INDEX IF NOT EXISTS idx_group_tx_memos_tx_hash
+  ON public.group_tx_memos(tx_hash);
+
+-- Enable RLS
+ALTER TABLE public.group_tx_memos ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read memo mappings (they are public identifiers)
+CREATE POLICY "Anyone can view group tx memos"
+  ON public.group_tx_memos FOR SELECT
+  USING (true);
+
+-- Only authenticated users (server-side) can insert
+CREATE POLICY "Authenticated users can insert group tx memos"
+  ON public.group_tx_memos FOR INSERT
+  WITH CHECK (auth.role() = 'authenticated');
+
+COMMENT ON TABLE public.group_tx_memos IS
+  'Lookup table mapping group IDs to Stellar transaction hashes via the memo field';
+COMMENT ON COLUMN public.group_tx_memos.memo_group_id IS
+  'The exact text stored in the Stellar transaction memo (≤28 bytes)';
+COMMENT ON COLUMN public.group_tx_memos.tx_hash IS
+  'Stellar transaction hash that contains this memo';

--- a/scripts/012_ephemeral_messages.sql
+++ b/scripts/012_ephemeral_messages.sql
@@ -1,0 +1,68 @@
+-- Migration 012: Ephemeral message TTL support
+-- Description: Adds TTL/expiry fields to messages and a per-room default TTL
+--              to support automatic deletion of ephemeral messages.
+-- Date: 2026-04-25
+
+-- ─── messages table ──────────────────────────────────────────────────────────
+
+-- Flag: is this message ephemeral (subject to TTL deletion)?
+ALTER TABLE public.messages
+  ADD COLUMN IF NOT EXISTS is_ephemeral BOOLEAN NOT NULL DEFAULT false;
+
+-- Absolute expiry timestamp; NULL means the message never expires.
+ALTER TABLE public.messages
+  ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ NULL;
+
+-- Partial index: only index ephemeral messages that have not yet expired.
+-- The cleanup worker uses this index for efficient batch queries.
+CREATE INDEX IF NOT EXISTS idx_messages_ephemeral_expires_at
+  ON public.messages (expires_at)
+  WHERE is_ephemeral = true AND expires_at IS NOT NULL;
+
+COMMENT ON COLUMN public.messages.is_ephemeral IS
+  'When true this message will be deleted by the cleanup worker once expires_at is reached';
+COMMENT ON COLUMN public.messages.expires_at IS
+  'UTC timestamp after which the message is eligible for deletion; NULL = never expires';
+
+-- ─── rooms table ─────────────────────────────────────────────────────────────
+
+-- Per-room default TTL in seconds.
+-- NULL means the room inherits the system-wide default (EPHEMERAL_TTL_SECONDS env var).
+-- 0 means messages in this room are never ephemeral by default.
+ALTER TABLE public.rooms
+  ADD COLUMN IF NOT EXISTS default_ttl_seconds INTEGER NULL
+  CONSTRAINT rooms_default_ttl_seconds_non_negative CHECK (default_ttl_seconds IS NULL OR default_ttl_seconds >= 0);
+
+COMMENT ON COLUMN public.rooms.default_ttl_seconds IS
+  'Default TTL in seconds for new messages in this room. NULL = inherit system default. 0 = non-ephemeral.';
+
+-- ─── RLS: service role bypass ────────────────────────────────────────────────
+-- The cleanup worker runs with the service role key and bypasses RLS by design.
+-- No additional policy is needed; service_role already bypasses all RLS policies.
+
+-- ─── Helper function: mark_message_ephemeral ─────────────────────────────────
+-- Convenience function callable from the API layer to set expiry on a message.
+CREATE OR REPLACE FUNCTION public.mark_message_ephemeral(
+  p_message_id UUID,
+  p_ttl_seconds INTEGER
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_ttl_seconds IS NULL OR p_ttl_seconds <= 0 THEN
+    RAISE EXCEPTION 'p_ttl_seconds must be a positive integer';
+  END IF;
+
+  UPDATE public.messages
+  SET
+    is_ephemeral = true,
+    expires_at   = timezone('utc', now()) + (p_ttl_seconds * INTERVAL '1 second')
+  WHERE id = p_message_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.mark_message_ephemeral(UUID, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.mark_message_ephemeral(UUID, INTEGER) TO service_role;

--- a/scripts/MIGRATIONS_README.md
+++ b/scripts/MIGRATIONS_README.md
@@ -11,6 +11,7 @@ Included migrations (apply in numeric order):
 - `005_add_last_read_to_room_members.sql` (new)
 - `006_unread_view.sql`          (new)
 - `007_create_group_membership.sql`  (new)
+- `012_ephemeral_messages.sql`   (new) — adds TTL columns to messages and rooms
 
 ## How to apply (psql)
 

--- a/scripts/MIGRATIONS_README.md
+++ b/scripts/MIGRATIONS_README.md
@@ -4,44 +4,113 @@ This repo includes SQL migration scripts in the `scripts/` folder. If you open a
 
 Included migrations (apply in numeric order):
 
-- `001_create_profiles.sql`
-- `002_create_profile_trigger.sql`
-- `003_create_invites.sql` (new)
-- `004_create_room_members.sql` (new)
-- `005_add_last_read_to_room_members.sql` (new)
-- `006_unread_view.sql`          (new)
-- `007_create_group_membership.sql`  (new)
-- `012_ephemeral_messages.sql`   (new) — adds TTL columns to messages and rooms
+| File | Description |
+|------|-------------|
+| `001_create_profiles.sql` | Creates the `profiles` table |
+| `002_create_profile_trigger.sql` | Trigger to auto-create a profile on user sign-up |
+| `003_create_invites.sql` | Invite codes table |
+| `003_add_blockchain_fields.sql` | Adds Stellar blockchain fields to rooms |
+| `003_room_members_and_removal_votes.sql` | Room members and vote-to-remove tables |
+| `004_create_room_members.sql` | Room membership table |
+| `005_add_last_read_to_room_members.sql` | Adds `last_read_at` for unread-count tracking |
+| `006_unread_view.sql` | Creates `user_room_unreads` view |
+| `007_create_group_membership.sql` | Wallet-based group membership tracking |
+| `007_secure_messages_rls.sql` | RLS policies for the messages table |
+| `008_create_groups.sql` | Groups table |
+| `009_encrypted_file_references.sql` | Encrypted file reference table |
+| `010_message_status.sql` | Adds `status` column to messages |
+| `011_stellar_memo_group_id.sql` | Stellar memo ↔ group ID mapping table |
+| `012_ephemeral_messages.sql` | **TTL columns** (`is_ephemeral`, `expires_at`) on messages; `default_ttl_seconds` on rooms; partial index; helper function |
 
 ## How to apply (psql)
 
-If you have direct DB access (preferred), run:
+If you have direct DB access (preferred), run each file in numeric order:
 
 ```bash
-# Example using a DATABASE_URL or connection string
 export DATABASE_URL="postgresql://<user>:<password>@<host>:5432/<database>"
 
-# Apply each file in order
 psql "$DATABASE_URL" -f scripts/001_create_profiles.sql
 psql "$DATABASE_URL" -f scripts/002_create_profile_trigger.sql
 psql "$DATABASE_URL" -f scripts/003_create_invites.sql
+psql "$DATABASE_URL" -f scripts/003_add_blockchain_fields.sql
+psql "$DATABASE_URL" -f scripts/003_room_members_and_removal_votes.sql
 psql "$DATABASE_URL" -f scripts/004_create_room_members.sql
 psql "$DATABASE_URL" -f scripts/005_add_last_read_to_room_members.sql
 psql "$DATABASE_URL" -f scripts/006_unread_view.sql
 psql "$DATABASE_URL" -f scripts/007_create_group_membership.sql
+psql "$DATABASE_URL" -f scripts/007_secure_messages_rls.sql
+psql "$DATABASE_URL" -f scripts/008_create_groups.sql
+psql "$DATABASE_URL" -f scripts/009_encrypted_file_references.sql
+psql "$DATABASE_URL" -f scripts/010_message_status.sql
+psql "$DATABASE_URL" -f scripts/011_stellar_memo_group_id.sql
+psql "$DATABASE_URL" -f scripts/012_ephemeral_messages.sql
 ```
 
 ## How to apply (Supabase)
 
-If the project uses Supabase, maintainers can run the same `psql` commands against the Supabase database connection string (available from the Supabase project settings), or use the Supabase dashboard SQL editor to run each migration in order.
+Use the Supabase dashboard SQL editor or the `psql` command with your project's connection string (available from **Project Settings → Database**). Run each file in the order listed above.
+
+## Ephemeral message cleanup worker
+
+Migration `012` enables the TTL system. After applying it you must also run the cleanup worker so expired messages are actually deleted.
+
+### Development
+
+```bash
+# Run Next.js + WebSocket server + cleanup worker concurrently
+npm run dev:all
+
+# Or start only the cleanup worker
+npm run dev:cleanup
+```
+
+### Production (self-hosted / Docker)
+
+Run the cleanup worker as a separate long-lived process alongside your Next.js server:
+
+```bash
+node scripts/start-cleanup-worker.js
+```
+
+Environment variables for the worker:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EPHEMERAL_TTL_SECONDS` | `86400` | System-wide default TTL in seconds (24 h) |
+| `EPHEMERAL_CLEANUP_INTERVAL_MS` | `300000` | How often the worker runs (5 min) |
+| `EPHEMERAL_CLEANUP_BATCH_SIZE` | `200` | Messages deleted per DB round-trip |
+| `NEXT_PUBLIC_SUPABASE_URL` | — | Supabase project URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | — | Service-role key (bypasses RLS for deletion) |
+
+### Production (Vercel / serverless)
+
+The repo ships a Vercel Cron endpoint at `/api/cron/ephemeral-cleanup` and a `vercel.json` that schedules it every 5 minutes. Set the `CRON_SECRET` environment variable in your Vercel project to secure the endpoint.
+
+### Admin API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/admin/ephemeral-cleanup` | Fetch current TTL config |
+| `POST` | `/api/admin/ephemeral-cleanup` | Trigger an immediate cleanup run |
+| `PATCH` | `/api/admin/ephemeral-cleanup` | Update system-wide default TTL at runtime |
+
+All admin endpoints require `Authorization: Bearer <ADMIN_SECRET>`.
+
+### Per-room TTL API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/rooms/:roomId/ttl` | Fetch a room's TTL config (members only) |
+| `PATCH` | `/api/rooms/:roomId/ttl` | Update a room's TTL (creator only) |
 
 ## Notes for maintainers
 
-- These migrations introduce new tables, columns, and a view. Review the RLS policies in each script before applying in production.
-- `scripts/005_add_last_read_to_room_members.sql` adds `last_read_at` used by the unread-count view.
-- `scripts/006_unread_view.sql` creates `public.user_room_unreads` view and grants `SELECT` to `public` for convenience; adjust privileges as needed.
-- `scripts/007_create_group_membership.sql` creates `public.group_membership` table for wallet-based group membership tracking.
-- A development-only endpoint (`/api/rooms/seed-test`) was added that seeds a room for an authenticated user. It requires a valid Supabase session; do not enable any service-role or unauthenticated behavior in production without review.
+- `005_add_last_read_to_room_members.sql` adds `last_read_at` used by the unread-count view.
+- `006_unread_view.sql` creates `public.user_room_unreads` view and grants `SELECT` to `public`; adjust privileges as needed.
+- `007_create_group_membership.sql` creates `public.group_membership` for wallet-based membership tracking.
+- `012_ephemeral_messages.sql` uses `ALTER TABLE … ADD COLUMN IF NOT EXISTS` so it is safe to re-run. The partial index and helper function are also idempotent (`CREATE INDEX IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`).
+- The cleanup worker uses the **service role key** to bypass RLS. Never expose this key client-side.
+- A development-only endpoint (`/api/rooms/seed-test`) seeds a room for an authenticated user. Do not enable unauthenticated access in production.
 
 ## Including migrations in PRs
 
@@ -49,9 +118,4 @@ When creating your PR:
 
 - Keep SQL files in `scripts/` and name them with a numeric prefix as above.
 - Add a short description in the PR body listing the migrations and any manual steps required (e.g., reindexing, backfills).
-- If you expect maintainers to run migrations, include the `psql` commands or reference this file so they can apply them during merging or in CI.
-
-If you'd like, I can also:
-
-- Add a simple Node script that runs the migrations using an env var `DATABASE_URL`.
-- Add a GitHub Actions workflow that will apply migrations to a staging database (if secrets are available).
+- Include the `psql` commands or reference this file so maintainers can apply them during merging or in CI.

--- a/scripts/start-cleanup-worker.js
+++ b/scripts/start-cleanup-worker.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+/**
+ * Ephemeral Message Cleanup Worker
+ * ─────────────────────────────────
+ * Runs the TTL-based message cleanup scheduler as a standalone Node.js process.
+ * Mirrors the pattern used by scripts/start-ws-server.js.
+ *
+ * Usage:
+ *   node scripts/start-cleanup-worker.js
+ *
+ * Environment variables (all optional):
+ *   EPHEMERAL_CLEANUP_INTERVAL_MS   How often to run (default: 300000 = 5 min)
+ *   EPHEMERAL_CLEANUP_BATCH_SIZE    Messages deleted per DB round-trip (default: 200)
+ *   NEXT_PUBLIC_SUPABASE_URL        Supabase project URL
+ *   SUPABASE_SERVICE_ROLE_KEY       Service-role key (bypasses RLS for deletion)
+ *
+ * The worker requires ts-node or a compiled build.  In development, run via:
+ *   npx ts-node --project tsconfig.json -e "require('./scripts/start-cleanup-worker.js')"
+ * or use the npm script:
+ *   npm run dev:cleanup
+ */
+
+// Register ts-node so we can import TypeScript modules directly in development.
+// In production (after `next build`) the compiled JS is used instead.
+try {
+  require("ts-node").register({
+    transpileOnly: true,
+    compilerOptions: { module: "commonjs" },
+  })
+} catch {
+  // ts-node not available — assume we're running compiled JS
+}
+
+// Path aliases (@/) are resolved via tsconfig-paths in development.
+try {
+  const tsConfigPaths = require("tsconfig-paths")
+  const tsConfig = require("../tsconfig.json")
+  const baseUrl = require("path").resolve(__dirname, "..")
+  tsConfigPaths.register({ baseUrl, paths: tsConfig.compilerOptions?.paths ?? {} })
+} catch {
+  // tsconfig-paths not available — aliases must be resolved by the build tool
+}
+
+const { startCleanupScheduler, stopCleanupScheduler } = require("../lib/ephemeral/scheduler")
+
+console.log("🧹 Starting ephemeral message cleanup worker...")
+
+try {
+  startCleanupScheduler(true)
+  console.log("✅ Cleanup worker running. Press Ctrl+C to stop.")
+} catch (err) {
+  console.error("❌ Failed to start cleanup worker:", err)
+  process.exit(1)
+}
+
+// ─── Graceful shutdown ────────────────────────────────────────────────────────
+
+async function shutdown(signal) {
+  console.log(`\n[cleanup-worker] Received ${signal} — shutting down gracefully...`)
+  try {
+    await stopCleanupScheduler()
+    console.log("[cleanup-worker] Shutdown complete.")
+  } catch (err) {
+    console.error("[cleanup-worker] Error during shutdown:", err)
+  }
+  process.exit(0)
+}
+
+process.on("SIGINT", () => shutdown("SIGINT"))
+process.on("SIGTERM", () => shutdown("SIGTERM"))

--- a/types/blockchain.ts
+++ b/types/blockchain.ts
@@ -13,6 +13,8 @@ export interface StellarTransactionResult {
   success: boolean;
   transactionHash?: string;
   feeCharged?: string;
+  /** The group memo embedded in the Stellar transaction (≤28 bytes). */
+  memoGroupId?: string;
   error?: string;
 }
 
@@ -30,6 +32,10 @@ export interface VerificationResponse {
   transactionHash: string | null;
   verified: boolean;
   explorerUrl: string | null;
+  /** The memo embedded in the transaction (should equal the derived group memo). */
+  memoGroupId?: string | null;
+  /** Whether the on-chain memo matches the expected group memo. */
+  memoVerified?: boolean;
 }
 
 export interface GroupCreationResponse {
@@ -43,6 +49,8 @@ export interface GroupCreationResponse {
     stellar_tx_hash: string | null;
     metadata_hash?: string | null;
     blockchain_submitted_at?: string | null;
+    /** Compact group identifier embedded in the Stellar memo (≤28 bytes). */
+    memo_group_id?: string | null;
   };
   success: boolean;
   blockchain: {
@@ -50,5 +58,7 @@ export interface GroupCreationResponse {
     transactionHash?: string;
     feeCharged?: string;
     explorerUrl?: string;
+    /** The memo value that was embedded in the on-chain transaction. */
+    memoGroupId?: string;
   };
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/ephemeral-cleanup",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION




- Add configurable TTL (default 24h) via EPHEMERAL_TTL_SECONDS env var
- Add background cleanup scheduler (setInterval, every 5 min) with overlap guard
- Add batch deletion with idempotency — already-deleted messages silently skipped
- Add structured audit logging of every deleted message ID with correlation run ID
- Add partial DB index on (expires_at) WHERE is_ephemeral = true for efficient queries
- Add per-room default TTL config (GET/PATCH /api/rooms/:roomId/ttl, creator-only)
- Add admin API (GET/POST/PATCH /api/admin/ephemeral-cleanup) for manual triggers and runtime config
- Add Vercel Cron endpoint (/api/cron/ephemeral-cleanup) for serverless deployments
- Add TTL selector (Default/Never/1h/24h/7d) to Create Group modal
- Add ephemeral toggle button to chat composer with amber visual indicator
- Add live countdown badge on ephemeral messages (updates every second)
- Fix dev:cleanup npm script
- Update MIGRATIONS_README with full deployment guide

Closes #112

