### PR TITLE
feat: stellar memo group ID linking and escrow lifecycle service

### DIFF
--- a/app/api/escrow/[escrowId]/dispute/route.ts
+++ b/app/api/escrow/[escrowId]/dispute/route.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/escrow/[escrowId]/dispute
+ * Raises a dispute on a funded escrow.
+ * Either the initiator or beneficiary can call this.
+ *
+ * Body: { reason: string }
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { disputeEscrow } from "@/lib/blockchain/escrow-service";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ escrowId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { escrowId } = await params;
+
+    const body = await request.json().catch(() => ({}));
+    const { reason } = body as { reason?: string };
+
+    if (!reason || typeof reason !== "string" || reason.trim().length === 0) {
+      return NextResponse.json(
+        { error: "reason is required and must be a non-empty string" },
+        { status: 400 }
+      );
+    }
+
+    // Resolve actor wallet from user profile
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("wallet_address")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const actorWallet = profile?.wallet_address as string | undefined;
+    if (!actorWallet) {
+      return NextResponse.json(
+        { error: "No wallet address found for your account" },
+        { status: 400 }
+      );
+    }
+
+    const result = await disputeEscrow({ escrowId, actorWallet, reason }, supabase);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ escrow: result.escrow });
+  } catch (error) {
+    console.error("[escrow/dispute] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/escrow/[escrowId]/fund/route.ts
+++ b/app/api/escrow/[escrowId]/fund/route.ts
@@ -1,0 +1,68 @@
+/**
+ * POST /api/escrow/[escrowId]/fund
+ * Marks an escrow as funded after the initiator has sent funds on-chain.
+ *
+ * Body: { fundTxHash: string }
+ *
+ * The caller must have already submitted the Stellar payment transaction
+ * and provide the resulting transaction hash.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { fundEscrow } from "@/lib/blockchain/escrow-service";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ escrowId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { escrowId } = await params;
+
+    const body = await request.json().catch(() => ({}));
+    const { fundTxHash } = body as { fundTxHash?: string };
+
+    if (!fundTxHash || typeof fundTxHash !== "string" || fundTxHash.trim() === "") {
+      return NextResponse.json(
+        { error: "fundTxHash is required" },
+        { status: 400 }
+      );
+    }
+
+    // Resolve actor wallet from user profile
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("wallet_address")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const actorWallet = profile?.wallet_address as string | undefined;
+    if (!actorWallet) {
+      return NextResponse.json(
+        { error: "No wallet address found for your account" },
+        { status: 400 }
+      );
+    }
+
+    const result = await fundEscrow({ escrowId, fundTxHash, actorWallet }, supabase);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ escrow: result.escrow, txHash: result.txHash });
+  } catch (error) {
+    console.error("[escrow/fund] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/escrow/[escrowId]/refund/route.ts
+++ b/app/api/escrow/[escrowId]/refund/route.ts
@@ -1,0 +1,67 @@
+/**
+ * POST /api/escrow/[escrowId]/refund
+ * Refunds escrowed funds back to the initiator.
+ *
+ * Who can call this:
+ *  - The beneficiary (at any time while funded)
+ *  - The initiator (only after the escrow has expired)
+ *
+ * Body: { maxFee?: number }
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { refundEscrow } from "@/lib/blockchain/escrow-service";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ escrowId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { escrowId } = await params;
+
+    const body = await request.json().catch(() => ({}));
+    const { maxFee } = body as { maxFee?: number };
+
+    // Resolve actor wallet from user profile
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("wallet_address")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const actorWallet = profile?.wallet_address as string | undefined;
+    if (!actorWallet) {
+      return NextResponse.json(
+        { error: "No wallet address found for your account" },
+        { status: 400 }
+      );
+    }
+
+    const result = await refundEscrow({ escrowId, actorWallet, maxFee }, supabase);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      escrow: result.escrow,
+      txHash: result.txHash,
+      explorerUrl: result.explorerUrl,
+      feeCharged: result.feeCharged,
+    });
+  } catch (error) {
+    console.error("[escrow/refund] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/escrow/[escrowId]/release/route.ts
+++ b/app/api/escrow/[escrowId]/release/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/escrow/[escrowId]/release
+ * Releases escrowed funds to the beneficiary.
+ * Only the escrow initiator can call this.
+ *
+ * Body: { maxFee?: number }
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { releaseEscrow } from "@/lib/blockchain/escrow-service";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ escrowId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { escrowId } = await params;
+
+    const body = await request.json().catch(() => ({}));
+    const { maxFee } = body as { maxFee?: number };
+
+    // Resolve actor wallet from user profile
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("wallet_address")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const actorWallet = profile?.wallet_address as string | undefined;
+    if (!actorWallet) {
+      return NextResponse.json(
+        { error: "No wallet address found for your account" },
+        { status: 400 }
+      );
+    }
+
+    const result = await releaseEscrow({ escrowId, actorWallet, maxFee }, supabase);
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      escrow: result.escrow,
+      txHash: result.txHash,
+      explorerUrl: result.explorerUrl,
+      feeCharged: result.feeCharged,
+    });
+  } catch (error) {
+    console.error("[escrow/release] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/escrow/[escrowId]/resolve/route.ts
+++ b/app/api/escrow/[escrowId]/resolve/route.ts
@@ -1,0 +1,74 @@
+/**
+ * POST /api/escrow/[escrowId]/resolve
+ * Resolves a disputed escrow by releasing funds to either party.
+ *
+ * This endpoint is restricted to authenticated users with a resolver role.
+ * In the current implementation, any authenticated user can resolve disputes
+ * (suitable for testnet / MVP). For production, add role-based access control
+ * or replace with DAO voting.
+ *
+ * Body: {
+ *   releaseToInitiator: boolean,  // true → refund initiator, false → pay beneficiary
+ *   maxFee?: number
+ * }
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { resolveDispute } from "@/lib/blockchain/escrow-service";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ escrowId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { escrowId } = await params;
+
+    const body = await request.json().catch(() => ({}));
+    const { releaseToInitiator, maxFee } = body as {
+      releaseToInitiator?: boolean;
+      maxFee?: number;
+    };
+
+    if (typeof releaseToInitiator !== "boolean") {
+      return NextResponse.json(
+        { error: "releaseToInitiator (boolean) is required" },
+        { status: 400 }
+      );
+    }
+
+    const result = await resolveDispute(
+      {
+        escrowId,
+        resolverUserId: user.id,
+        releaseToInitiator,
+        maxFee,
+      },
+      supabase
+    );
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      escrow: result.escrow,
+      txHash: result.txHash,
+      explorerUrl: result.explorerUrl,
+      feeCharged: result.feeCharged,
+    });
+  } catch (error) {
+    console.error("[escrow/resolve] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/escrow/[escrowId]/route.ts
+++ b/app/api/escrow/[escrowId]/route.ts
@@ -1,0 +1,39 @@
+/**
+ * GET /api/escrow/[escrowId]
+ * Returns a single escrow record with its event history.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getEscrow, getEscrowEvents } from "@/lib/blockchain/escrow-service";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ escrowId: string }> }
+) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { escrowId } = await params;
+
+    const result = await getEscrow(escrowId, supabase);
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 404 });
+    }
+
+    const events = await getEscrowEvents(escrowId, supabase);
+
+    return NextResponse.json({ escrow: result.escrow, events });
+  } catch (error) {
+    console.error("[escrow/[escrowId]] GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/escrow/route.ts
+++ b/app/api/escrow/route.ts
@@ -1,0 +1,161 @@
+/**
+ * POST /api/escrow
+ * Creates a new escrow record (status: pending).
+ *
+ * Body: {
+ *   groupId: string,
+ *   beneficiaryWallet: string,
+ *   amountXlm: number,
+ *   assetCode?: string,
+ *   expiresAt?: string  // ISO-8601
+ * }
+ *
+ * GET /api/escrow?groupId=<id>
+ * Lists all escrows for a group.
+ *
+ * GET /api/escrow?wallet=<address>
+ * Lists all escrows where the wallet is initiator or beneficiary.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import {
+  createEscrow,
+  listEscrowsByGroup,
+  listEscrowsByWallet,
+} from "@/lib/blockchain/escrow-service";
+import { validateStellarAddress } from "@/lib/auth/validation";
+
+// ── POST — create escrow ──────────────────────────────────────────────────────
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const { groupId, beneficiaryWallet, amountXlm, assetCode, expiresAt } = body as {
+      groupId?: string;
+      beneficiaryWallet?: string;
+      amountXlm?: number;
+      assetCode?: string;
+      expiresAt?: string;
+    };
+
+    // Resolve initiator wallet from user profile
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("wallet_address")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const initiatorWallet = profile?.wallet_address as string | undefined;
+
+    if (!initiatorWallet) {
+      return NextResponse.json(
+        { error: "No wallet address found for your account" },
+        { status: 400 }
+      );
+    }
+
+    // Input validation
+    if (!groupId) {
+      return NextResponse.json({ error: "groupId is required" }, { status: 400 });
+    }
+
+    if (!beneficiaryWallet || !validateStellarAddress(beneficiaryWallet)) {
+      return NextResponse.json(
+        { error: "beneficiaryWallet must be a valid Stellar address" },
+        { status: 400 }
+      );
+    }
+
+    if (!amountXlm || typeof amountXlm !== "number" || amountXlm <= 0) {
+      return NextResponse.json(
+        { error: "amountXlm must be a positive number" },
+        { status: 400 }
+      );
+    }
+
+    if (expiresAt && isNaN(Date.parse(expiresAt))) {
+      return NextResponse.json(
+        { error: "expiresAt must be a valid ISO-8601 datetime" },
+        { status: 400 }
+      );
+    }
+
+    const result = await createEscrow(
+      {
+        groupId,
+        initiatorWallet,
+        beneficiaryWallet,
+        amountXlm,
+        assetCode,
+        expiresAt,
+      },
+      supabase
+    );
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    return NextResponse.json({ escrow: result.escrow }, { status: 201 });
+  } catch (error) {
+    console.error("[escrow] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ── GET — list escrows ────────────────────────────────────────────────────────
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const groupId = searchParams.get("groupId");
+    const wallet = searchParams.get("wallet");
+
+    if (!groupId && !wallet) {
+      return NextResponse.json(
+        { error: "Provide either groupId or wallet query parameter" },
+        { status: 400 }
+      );
+    }
+
+    if (groupId) {
+      const escrows = await listEscrowsByGroup(groupId, supabase);
+      return NextResponse.json({ escrows });
+    }
+
+    if (wallet) {
+      if (!validateStellarAddress(wallet)) {
+        return NextResponse.json(
+          { error: "wallet must be a valid Stellar address" },
+          { status: 400 }
+        );
+      }
+      const escrows = await listEscrowsByWallet(wallet, supabase);
+      return NextResponse.json({ escrows });
+    }
+  } catch (error) {
+    console.error("[escrow] GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -5,6 +5,7 @@ import {
   submitMetadataHash,
   getTransactionExplorerUrl,
 } from "@/lib/blockchain/stellar-service";
+import { submitGroupMemoTransaction } from "@/lib/blockchain/memo-service";
 import { GroupMetadata } from "@/types/blockchain";
 import {
   logBlockchainOperation,
@@ -181,6 +182,47 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Submit a dedicated group-ID memo transaction (non-blocking, graceful degradation)
+    let memoTxHash: string | null = null;
+    let memoValue: string | null = null;
+    let memoType: string | null = null;
+
+    try {
+      const memoResult = await submitGroupMemoTransaction(
+        room.id,
+        supabase,
+        user.id,
+        max_fee
+      );
+
+      if (memoResult.success) {
+        memoTxHash = memoResult.txHash ?? null;
+        memoValue = memoResult.memoValue ?? null;
+        memoType = memoResult.memoType ?? null;
+
+        logBlockchainOperation(
+          "info",
+          "Group memo transaction submitted",
+          { groupId: room.id, memoTxHash, memoValue, memoType },
+          correlationId,
+        );
+      } else {
+        logBlockchainOperation(
+          "warn",
+          "Group memo transaction failed, continuing without it",
+          { groupId: room.id, error: memoResult.error ? { type: "MemoError", message: memoResult.error } : undefined },
+          correlationId,
+        );
+      }
+    } catch (memoError: any) {
+      logBlockchainOperation(
+        "error",
+        "Group memo transaction error",
+        { groupId: room.id, error: { type: memoError.name || "UnknownError", message: memoError.message || "Unknown error" } },
+        correlationId,
+      );
+    }
+
     // Return success response with blockchain info
     return NextResponse.json(
       {
@@ -195,6 +237,9 @@ export async function POST(request: NextRequest) {
           transactionHash: stellarTxHash || undefined,
           feeCharged: actualFeeCharged || undefined,
           explorerUrl: explorerUrl || undefined,
+          memo: memoTxHash
+            ? { txHash: memoTxHash, memoValue, memoType }
+            : undefined,
         },
       },
       { status: 201 },

--- a/app/api/stellar/memo/route.ts
+++ b/app/api/stellar/memo/route.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/stellar/memo
+ * Submits a Stellar transaction with the group ID embedded in the memo field
+ * and persists the groupId ↔ txHash mapping in the database.
+ *
+ * Body: { groupId: string, maxFee?: number }
+ *
+ * GET /api/stellar/memo?groupId=<id>
+ * Returns all memo records for a group, with validation status.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { submitGroupMemoTransaction, getMemosByGroupId, validateMemoRecord } from "@/lib/blockchain/memo-service";
+import { validateGroupIdExists, getMemoStrategyInfo } from "@/lib/blockchain/memo-validation";
+
+// ── POST — submit a memo transaction ─────────────────────────────────────────
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const { groupId, maxFee } = body as { groupId?: string; maxFee?: number };
+
+    // Validate groupId exists
+    const groupCheck = await validateGroupIdExists(groupId ?? "", supabase);
+    if (!groupCheck.valid) return groupCheck.response;
+
+    // Provide strategy info for transparency
+    const strategyInfo = getMemoStrategyInfo(groupId!);
+
+    // Submit the memo transaction
+    const result = await submitGroupMemoTransaction(
+      groupId!,
+      supabase,
+      user.id,
+      maxFee
+    );
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error ?? "Failed to submit memo transaction" },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        groupId,
+        txHash: result.txHash,
+        memoValue: result.memoValue,
+        memoType: result.memoType,
+        explorerUrl: result.explorerUrl,
+        feeCharged: result.feeCharged,
+        strategy: strategyInfo,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[stellar/memo] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ── GET — retrieve memo records for a group ───────────────────────────────────
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const groupId = searchParams.get("groupId");
+
+    if (!groupId) {
+      return NextResponse.json(
+        { error: "groupId query parameter is required" },
+        { status: 400 }
+      );
+    }
+
+    // Validate group exists
+    const groupCheck = await validateGroupIdExists(groupId, supabase);
+    if (!groupCheck.valid) return groupCheck.response;
+
+    const records = await getMemosByGroupId(groupId, supabase);
+
+    // Run in-memory validation on each record
+    const validated = records.map((r) => ({
+      ...r,
+      validation: validateMemoRecord(r),
+    }));
+
+    return NextResponse.json({
+      groupId,
+      memos: validated,
+      strategy: getMemoStrategyInfo(groupId),
+    });
+  } catch (error) {
+    console.error("[stellar/memo] GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/stellar/memo/validate/route.ts
+++ b/app/api/stellar/memo/validate/route.ts
@@ -1,0 +1,65 @@
+/**
+ * POST /api/stellar/memo/validate
+ * Validates memo integrity for a given groupId + txHash pair.
+ *
+ * Body: { groupId: string, txHash: string }
+ *
+ * Returns whether the memo record exists, is linked to the correct group,
+ * and passes integrity checks.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getMemoByTxHash, validateMemoRecord } from "@/lib/blockchain/memo-service";
+import {
+  validateGroupIdExists,
+  validateTxMemoRecord,
+} from "@/lib/blockchain/memo-validation";
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const { groupId, txHash } = body as { groupId?: string; txHash?: string };
+
+    // Validate groupId
+    const groupCheck = await validateGroupIdExists(groupId ?? "", supabase);
+    if (!groupCheck.valid) return groupCheck.response;
+
+    // Validate txHash against DB record
+    const txCheck = await validateTxMemoRecord(txHash ?? "", groupId!, supabase);
+    if (!txCheck.valid) return txCheck.response;
+
+    // Fetch the record and run full validation
+    const record = await getMemoByTxHash(txHash!, supabase);
+    if (!record) {
+      return NextResponse.json(
+        { error: "Memo record not found" },
+        { status: 404 }
+      );
+    }
+
+    const validation = validateMemoRecord(record);
+
+    return NextResponse.json({
+      valid: validation.isValid,
+      groupId: validation.groupId,
+      txHash: validation.txHash,
+      memoValue: validation.memoValue,
+      memoType: validation.memoType,
+      verifiedAt: validation.verifiedAt,
+    });
+  } catch (error) {
+    console.error("[stellar/memo/validate] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/lib/blockchain/escrow-service.ts
+++ b/lib/blockchain/escrow-service.ts
@@ -1,0 +1,821 @@
+/**
+ * Escrow Lifecycle Service
+ *
+ * Abstracts all blockchain interactions for escrow operations away from
+ * controllers. Each function follows the pattern:
+ *   1. Validate inputs & current escrow state
+ *   2. Execute on-chain operation (if required)
+ *   3. Persist state change + event log in DB
+ *   4. Return a clean EscrowResult
+ *
+ * Supported lifecycle:
+ *   createEscrow → fundEscrow → releaseEscrow
+ *                            ↘ refundEscrow
+ *                            ↘ disputeEscrow → resolveDispute
+ *
+ * Design principles:
+ *  - All blockchain logic lives here; controllers only call service functions
+ *  - Graceful degradation: DB state is always updated even if on-chain fails
+ *  - Modular: each lifecycle step is an independent, testable function
+ *  - Extensible: dispute resolution can be upgraded to DAO voting later
+ */
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { loadStellarConfig, isConfigured, getExplorerUrl } from "./stellar-config";
+import { logBlockchainOperation, generateCorrelationId } from "./logger";
+import { buildGroupMemo } from "./memo";
+import {
+  EscrowRecord,
+  EscrowResult,
+  EscrowStatus,
+  EscrowEventType,
+  CreateEscrowInput,
+  FundEscrowInput,
+  ReleaseEscrowInput,
+  RefundEscrowInput,
+  DisputeEscrowInput,
+  ResolveDisputeInput,
+} from "@/types/escrow";
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Appends a row to the escrow_events audit log.
+ * Non-fatal: errors are logged but do not throw.
+ */
+async function logEscrowEvent(
+  supabase: SupabaseClient,
+  escrowId: string,
+  eventType: EscrowEventType,
+  opts: {
+    txHash?: string;
+    actorWallet?: string;
+    metadata?: Record<string, unknown>;
+  } = {}
+): Promise<void> {
+  const { error } = await supabase.from("escrow_events").insert({
+    escrow_id: escrowId,
+    event_type: eventType,
+    tx_hash: opts.txHash ?? null,
+    actor_wallet: opts.actorWallet ?? null,
+    metadata: opts.metadata ?? {},
+  });
+
+  if (error) {
+    console.error(`[EscrowService] Failed to log event '${eventType}' for escrow ${escrowId}:`, error.message);
+  }
+}
+
+/**
+ * Fetches an escrow record by ID. Returns null if not found.
+ */
+async function fetchEscrow(
+  escrowId: string,
+  supabase: SupabaseClient
+): Promise<EscrowRecord | null> {
+  const { data, error } = await supabase
+    .from("escrows")
+    .select("*")
+    .eq("id", escrowId)
+    .maybeSingle();
+
+  if (error) {
+    logBlockchainOperation("error", "Failed to fetch escrow", {
+      escrowId,
+      error: { type: "DBError", message: error.message },
+    });
+    return null;
+  }
+
+  return data as EscrowRecord | null;
+}
+
+/**
+ * Asserts that an escrow is in one of the allowed statuses.
+ * Returns an error result if the assertion fails.
+ */
+function assertStatus(
+  escrow: EscrowRecord,
+  allowed: EscrowStatus[]
+): EscrowResult | null {
+  if (!allowed.includes(escrow.status)) {
+    return {
+      success: false,
+      error: `Escrow is in '${escrow.status}' status; expected one of: ${allowed.join(", ")}`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Submits a Stellar payment transaction.
+ * Used for release and refund operations.
+ */
+async function submitPayment(opts: {
+  destinationPublicKey: string;
+  amountXlm: string;
+  groupId: string;
+  memo?: StellarSdk.Memo;
+  maxFee?: string | number;
+}): Promise<{ success: boolean; txHash?: string; feeCharged?: string; error?: string }> {
+  const correlationId = generateCorrelationId();
+
+  if (!isConfigured()) {
+    return { success: false, error: "Stellar configuration not available" };
+  }
+
+  const config = loadStellarConfig();
+  if (!config) {
+    return { success: false, error: "Failed to load Stellar configuration" };
+  }
+
+  try {
+    const server = new StellarSdk.Horizon.Server(config.horizonUrl);
+    const sourceKeypair = StellarSdk.Keypair.fromSecret(config.sourceSecret);
+    const sourcePublicKey = sourceKeypair.publicKey();
+
+    const account = await Promise.race([
+      server.loadAccount(sourcePublicKey),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Timeout loading account")), config.transactionTimeout)
+      ),
+    ]);
+
+    const feeToUse = opts.maxFee ? opts.maxFee.toString() : StellarSdk.BASE_FEE;
+
+    const builder = new StellarSdk.TransactionBuilder(account, {
+      fee: feeToUse,
+      networkPassphrase:
+        config.network === "testnet"
+          ? StellarSdk.Networks.TESTNET
+          : StellarSdk.Networks.PUBLIC,
+    }).addOperation(
+      StellarSdk.Operation.payment({
+        destination: opts.destinationPublicKey,
+        asset: StellarSdk.Asset.native(),
+        amount: opts.amountXlm,
+      })
+    );
+
+    // Attach memo if provided, otherwise embed group ID
+    const memo = opts.memo ?? buildGroupMemo(opts.groupId).memo;
+    builder.addMemo(memo);
+
+    const transaction = builder.setTimeout(30).build();
+    transaction.sign(sourceKeypair);
+
+    const result = await Promise.race([
+      server.submitTransaction(transaction),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Transaction submission timeout")), config.transactionTimeout)
+      ),
+    ]);
+
+    const feeCharged = (result as any).fee_charged?.toString() ?? feeToUse.toString();
+
+    logBlockchainOperation(
+      "info",
+      "Payment transaction submitted",
+      { groupId: opts.groupId, txHash: result.hash, feeCharged },
+      correlationId
+    );
+
+    return { success: true, txHash: result.hash, feeCharged };
+  } catch (error: any) {
+    logBlockchainOperation(
+      "error",
+      "Payment transaction failed",
+      {
+        groupId: opts.groupId,
+        error: { type: error.name ?? "UnknownError", message: error.message ?? "Unknown" },
+      },
+      correlationId
+    );
+    return { success: false, error: error.message ?? "Transaction failed" };
+  }
+}
+
+// ── Public service functions ──────────────────────────────────────────────────
+
+/**
+ * Creates a new escrow record in the DB (status: "pending").
+ * No on-chain transaction at this stage — funds are committed in fundEscrow().
+ *
+ * @param input    - Escrow creation parameters
+ * @param supabase - Supabase client (service-role recommended)
+ */
+export async function createEscrow(
+  input: CreateEscrowInput,
+  supabase: SupabaseClient
+): Promise<EscrowResult> {
+  const correlationId = generateCorrelationId();
+
+  // Basic input validation
+  if (!input.groupId || !input.initiatorWallet || !input.beneficiaryWallet) {
+    return { success: false, error: "groupId, initiatorWallet, and beneficiaryWallet are required" };
+  }
+
+  if (input.amountXlm <= 0) {
+    return { success: false, error: "amountXlm must be greater than 0" };
+  }
+
+  if (input.initiatorWallet === input.beneficiaryWallet) {
+    return { success: false, error: "initiatorWallet and beneficiaryWallet must be different" };
+  }
+
+  // Validate Stellar addresses
+  try {
+    StellarSdk.Keypair.fromPublicKey(input.initiatorWallet);
+    StellarSdk.Keypair.fromPublicKey(input.beneficiaryWallet);
+  } catch {
+    return { success: false, error: "Invalid Stellar wallet address" };
+  }
+
+  // Verify group exists
+  const { data: group, error: groupError } = await supabase
+    .from("rooms")
+    .select("id")
+    .eq("id", input.groupId)
+    .maybeSingle();
+
+  if (groupError || !group) {
+    return { success: false, error: `Group '${input.groupId}' not found` };
+  }
+
+  // Build the memo group ID reference
+  const { memoValue } = buildGroupMemo(input.groupId);
+
+  const { data, error } = await supabase
+    .from("escrows")
+    .insert({
+      group_id: input.groupId,
+      initiator_wallet: input.initiatorWallet,
+      beneficiary_wallet: input.beneficiaryWallet,
+      amount_xlm: input.amountXlm,
+      asset_code: input.assetCode ?? "XLM",
+      asset_issuer: input.assetIssuer ?? null,
+      status: "pending" as EscrowStatus,
+      memo_group_id: memoValue,
+      expires_at: input.expiresAt ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    logBlockchainOperation(
+      "error",
+      "Failed to create escrow record",
+      { groupId: input.groupId, error: { type: "DBError", message: error.message } },
+      correlationId
+    );
+    return { success: false, error: "Failed to create escrow record" };
+  }
+
+  const escrow = data as EscrowRecord;
+
+  await logEscrowEvent(supabase, escrow.id, "created", {
+    actorWallet: input.initiatorWallet,
+    metadata: {
+      groupId: input.groupId,
+      amountXlm: input.amountXlm,
+      beneficiaryWallet: input.beneficiaryWallet,
+    },
+  });
+
+  logBlockchainOperation(
+    "info",
+    "Escrow created",
+    { escrowId: escrow.id, groupId: input.groupId, amountXlm: input.amountXlm },
+    correlationId
+  );
+
+  return { success: true, escrow };
+}
+
+/**
+ * Marks an escrow as funded after the initiator has sent funds on-chain.
+ * The caller is responsible for submitting the funding transaction and
+ * providing the resulting txHash.
+ *
+ * Status transition: pending → funded
+ *
+ * @param input    - Fund escrow parameters (includes the on-chain txHash)
+ * @param supabase - Supabase client
+ */
+export async function fundEscrow(
+  input: FundEscrowInput,
+  supabase: SupabaseClient
+): Promise<EscrowResult> {
+  const correlationId = generateCorrelationId();
+
+  const escrow = await fetchEscrow(input.escrowId, supabase);
+  if (!escrow) {
+    return { success: false, error: `Escrow '${input.escrowId}' not found` };
+  }
+
+  const statusError = assertStatus(escrow, ["pending"]);
+  if (statusError) return statusError;
+
+  if (escrow.initiator_wallet !== input.actorWallet) {
+    return { success: false, error: "Only the escrow initiator can fund it" };
+  }
+
+  // Check expiry
+  if (escrow.expires_at && new Date(escrow.expires_at) < new Date()) {
+    return { success: false, error: "Escrow has expired and cannot be funded" };
+  }
+
+  const { data, error } = await supabase
+    .from("escrows")
+    .update({
+      status: "funded" as EscrowStatus,
+      fund_tx_hash: input.fundTxHash,
+      funded_at: new Date().toISOString(),
+    })
+    .eq("id", input.escrowId)
+    .select()
+    .single();
+
+  if (error) {
+    return { success: false, error: "Failed to update escrow status" };
+  }
+
+  const updated = data as EscrowRecord;
+
+  await logEscrowEvent(supabase, escrow.id, "funded", {
+    txHash: input.fundTxHash,
+    actorWallet: input.actorWallet,
+    metadata: { amountXlm: escrow.amount_xlm },
+  });
+
+  logBlockchainOperation(
+    "info",
+    "Escrow funded",
+    { escrowId: escrow.id, txHash: input.fundTxHash },
+    correlationId
+  );
+
+  return { success: true, escrow: updated, txHash: input.fundTxHash };
+}
+
+/**
+ * Releases escrowed funds to the beneficiary.
+ * Submits a Stellar payment transaction from the service wallet to the beneficiary.
+ *
+ * Status transition: funded → released
+ *
+ * @param input    - Release parameters
+ * @param supabase - Supabase client
+ */
+export async function releaseEscrow(
+  input: ReleaseEscrowInput,
+  supabase: SupabaseClient
+): Promise<EscrowResult> {
+  const correlationId = generateCorrelationId();
+
+  const escrow = await fetchEscrow(input.escrowId, supabase);
+  if (!escrow) {
+    return { success: false, error: `Escrow '${input.escrowId}' not found` };
+  }
+
+  const statusError = assertStatus(escrow, ["funded"]);
+  if (statusError) return statusError;
+
+  // Only the initiator can release (or a resolver in dispute flow)
+  if (escrow.initiator_wallet !== input.actorWallet) {
+    return { success: false, error: "Only the escrow initiator can release funds" };
+  }
+
+  // Submit on-chain payment to beneficiary
+  const payment = await submitPayment({
+    destinationPublicKey: escrow.beneficiary_wallet,
+    amountXlm: escrow.amount_xlm.toFixed(7),
+    groupId: escrow.group_id,
+    maxFee: input.maxFee,
+  });
+
+  if (!payment.success) {
+    await logEscrowEvent(supabase, escrow.id, "error", {
+      actorWallet: input.actorWallet,
+      metadata: { operation: "release", error: payment.error },
+    });
+    return { success: false, error: payment.error };
+  }
+
+  const config = loadStellarConfig();
+  const explorerUrl = config && payment.txHash
+    ? getExplorerUrl(payment.txHash, config.network)
+    : undefined;
+
+  const { data, error } = await supabase
+    .from("escrows")
+    .update({
+      status: "released" as EscrowStatus,
+      release_tx_hash: payment.txHash,
+      released_at: new Date().toISOString(),
+    })
+    .eq("id", input.escrowId)
+    .select()
+    .single();
+
+  if (error) {
+    logBlockchainOperation(
+      "warn",
+      "Escrow released on-chain but DB update failed",
+      { escrowId: escrow.id, txHash: payment.txHash, error: { type: "DBError", message: error.message } },
+      correlationId
+    );
+  }
+
+  await logEscrowEvent(supabase, escrow.id, "released", {
+    txHash: payment.txHash,
+    actorWallet: input.actorWallet,
+    metadata: { amountXlm: escrow.amount_xlm, beneficiaryWallet: escrow.beneficiary_wallet },
+  });
+
+  logBlockchainOperation(
+    "info",
+    "Escrow released",
+    { escrowId: escrow.id, txHash: payment.txHash, beneficiary: escrow.beneficiary_wallet },
+    correlationId
+  );
+
+  return {
+    success: true,
+    escrow: (data ?? escrow) as EscrowRecord,
+    txHash: payment.txHash,
+    explorerUrl,
+    feeCharged: payment.feeCharged,
+  };
+}
+
+/**
+ * Refunds escrowed funds back to the initiator.
+ * Submits a Stellar payment transaction from the service wallet to the initiator.
+ *
+ * Status transition: funded → refunded
+ *
+ * @param input    - Refund parameters
+ * @param supabase - Supabase client
+ */
+export async function refundEscrow(
+  input: RefundEscrowInput,
+  supabase: SupabaseClient
+): Promise<EscrowResult> {
+  const correlationId = generateCorrelationId();
+
+  const escrow = await fetchEscrow(input.escrowId, supabase);
+  if (!escrow) {
+    return { success: false, error: `Escrow '${input.escrowId}' not found` };
+  }
+
+  const statusError = assertStatus(escrow, ["funded"]);
+  if (statusError) return statusError;
+
+  // Beneficiary can request a refund, or the initiator can self-refund after expiry
+  const isInitiator = escrow.initiator_wallet === input.actorWallet;
+  const isBeneficiary = escrow.beneficiary_wallet === input.actorWallet;
+  const isExpired = escrow.expires_at ? new Date(escrow.expires_at) < new Date() : false;
+
+  if (!isBeneficiary && !(isInitiator && isExpired)) {
+    return {
+      success: false,
+      error: isInitiator
+        ? "Initiator can only self-refund after the escrow has expired"
+        : "Only the beneficiary or the initiator (after expiry) can request a refund",
+    };
+  }
+
+  // Submit on-chain payment back to initiator
+  const payment = await submitPayment({
+    destinationPublicKey: escrow.initiator_wallet,
+    amountXlm: escrow.amount_xlm.toFixed(7),
+    groupId: escrow.group_id,
+    maxFee: input.maxFee,
+  });
+
+  if (!payment.success) {
+    await logEscrowEvent(supabase, escrow.id, "error", {
+      actorWallet: input.actorWallet,
+      metadata: { operation: "refund", error: payment.error },
+    });
+    return { success: false, error: payment.error };
+  }
+
+  const config = loadStellarConfig();
+  const explorerUrl = config && payment.txHash
+    ? getExplorerUrl(payment.txHash, config.network)
+    : undefined;
+
+  const { data, error } = await supabase
+    .from("escrows")
+    .update({
+      status: "refunded" as EscrowStatus,
+      refund_tx_hash: payment.txHash,
+      refunded_at: new Date().toISOString(),
+    })
+    .eq("id", input.escrowId)
+    .select()
+    .single();
+
+  if (error) {
+    logBlockchainOperation(
+      "warn",
+      "Escrow refunded on-chain but DB update failed",
+      { escrowId: escrow.id, txHash: payment.txHash, error: { type: "DBError", message: error.message } },
+      correlationId
+    );
+  }
+
+  await logEscrowEvent(supabase, escrow.id, "refunded", {
+    txHash: payment.txHash,
+    actorWallet: input.actorWallet,
+    metadata: { amountXlm: escrow.amount_xlm, initiatorWallet: escrow.initiator_wallet },
+  });
+
+  logBlockchainOperation(
+    "info",
+    "Escrow refunded",
+    { escrowId: escrow.id, txHash: payment.txHash, initiator: escrow.initiator_wallet },
+    correlationId
+  );
+
+  return {
+    success: true,
+    escrow: (data ?? escrow) as EscrowRecord,
+    txHash: payment.txHash,
+    explorerUrl,
+    feeCharged: payment.feeCharged,
+  };
+}
+
+/**
+ * Raises a dispute on a funded escrow.
+ * No on-chain transaction — marks the escrow for manual/DAO resolution.
+ *
+ * Status transition: funded → disputed
+ *
+ * @param input    - Dispute parameters
+ * @param supabase - Supabase client
+ */
+export async function disputeEscrow(
+  input: DisputeEscrowInput,
+  supabase: SupabaseClient
+): Promise<EscrowResult> {
+  const correlationId = generateCorrelationId();
+
+  const escrow = await fetchEscrow(input.escrowId, supabase);
+  if (!escrow) {
+    return { success: false, error: `Escrow '${input.escrowId}' not found` };
+  }
+
+  const statusError = assertStatus(escrow, ["funded"]);
+  if (statusError) return statusError;
+
+  // Either party can raise a dispute
+  const isParticipant =
+    escrow.initiator_wallet === input.actorWallet ||
+    escrow.beneficiary_wallet === input.actorWallet;
+
+  if (!isParticipant) {
+    return { success: false, error: "Only escrow participants can raise a dispute" };
+  }
+
+  if (!input.reason || input.reason.trim().length === 0) {
+    return { success: false, error: "A dispute reason is required" };
+  }
+
+  const { data, error } = await supabase
+    .from("escrows")
+    .update({
+      status: "disputed" as EscrowStatus,
+      dispute_reason: input.reason.trim(),
+      disputed_at: new Date().toISOString(),
+    })
+    .eq("id", input.escrowId)
+    .select()
+    .single();
+
+  if (error) {
+    return { success: false, error: "Failed to update escrow status" };
+  }
+
+  await logEscrowEvent(supabase, escrow.id, "disputed", {
+    actorWallet: input.actorWallet,
+    metadata: { reason: input.reason },
+  });
+
+  logBlockchainOperation(
+    "info",
+    "Escrow disputed",
+    { escrowId: escrow.id, actorWallet: input.actorWallet },
+    correlationId
+  );
+
+  return { success: true, escrow: data as EscrowRecord };
+}
+
+/**
+ * Resolves a disputed escrow by releasing funds to either party.
+ * Submits the appropriate on-chain payment based on the resolver's decision.
+ *
+ * Status transition: disputed → resolved
+ *
+ * Extensibility note: the resolverUserId can be replaced with a DAO vote
+ * result or multi-sig approval in future iterations.
+ *
+ * @param input    - Resolution parameters
+ * @param supabase - Supabase client
+ */
+export async function resolveDispute(
+  input: ResolveDisputeInput,
+  supabase: SupabaseClient
+): Promise<EscrowResult> {
+  const correlationId = generateCorrelationId();
+
+  const escrow = await fetchEscrow(input.escrowId, supabase);
+  if (!escrow) {
+    return { success: false, error: `Escrow '${input.escrowId}' not found` };
+  }
+
+  const statusError = assertStatus(escrow, ["disputed"]);
+  if (statusError) return statusError;
+
+  // Determine destination based on resolution decision
+  const destinationWallet = input.releaseToInitiator
+    ? escrow.initiator_wallet
+    : escrow.beneficiary_wallet;
+
+  const payment = await submitPayment({
+    destinationPublicKey: destinationWallet,
+    amountXlm: escrow.amount_xlm.toFixed(7),
+    groupId: escrow.group_id,
+    maxFee: input.maxFee,
+  });
+
+  if (!payment.success) {
+    await logEscrowEvent(supabase, escrow.id, "error", {
+      metadata: { operation: "resolve", error: payment.error },
+    });
+    return { success: false, error: payment.error };
+  }
+
+  const config = loadStellarConfig();
+  const explorerUrl = config && payment.txHash
+    ? getExplorerUrl(payment.txHash, config.network)
+    : undefined;
+
+  // Determine final status based on where funds went
+  const finalStatus: EscrowStatus = input.releaseToInitiator ? "refunded" : "released";
+  const txField = input.releaseToInitiator ? "refund_tx_hash" : "release_tx_hash";
+  const timestampField = input.releaseToInitiator ? "refunded_at" : "released_at";
+
+  const { data, error } = await supabase
+    .from("escrows")
+    .update({
+      status: "resolved" as EscrowStatus,
+      [txField]: payment.txHash,
+      [timestampField]: new Date().toISOString(),
+      resolved_by: input.resolverUserId,
+      resolved_at: new Date().toISOString(),
+    })
+    .eq("id", input.escrowId)
+    .select()
+    .single();
+
+  if (error) {
+    logBlockchainOperation(
+      "warn",
+      "Dispute resolved on-chain but DB update failed",
+      { escrowId: escrow.id, txHash: payment.txHash, error: { type: "DBError", message: error.message } },
+      correlationId
+    );
+  }
+
+  await logEscrowEvent(supabase, escrow.id, "resolved", {
+    txHash: payment.txHash,
+    metadata: {
+      resolverUserId: input.resolverUserId,
+      releaseToInitiator: input.releaseToInitiator,
+      destinationWallet,
+    },
+  });
+
+  logBlockchainOperation(
+    "info",
+    "Dispute resolved",
+    {
+      escrowId: escrow.id,
+      txHash: payment.txHash,
+      destinationWallet,
+      finalStatus,
+    },
+    correlationId
+  );
+
+  return {
+    success: true,
+    escrow: (data ?? escrow) as EscrowRecord,
+    txHash: payment.txHash,
+    explorerUrl,
+    feeCharged: payment.feeCharged,
+  };
+}
+
+/**
+ * Retrieves a single escrow record by ID.
+ *
+ * @param escrowId - UUID of the escrow
+ * @param supabase - Supabase client
+ */
+export async function getEscrow(
+  escrowId: string,
+  supabase: SupabaseClient
+): Promise<EscrowResult> {
+  const escrow = await fetchEscrow(escrowId, supabase);
+  if (!escrow) {
+    return { success: false, error: `Escrow '${escrowId}' not found` };
+  }
+  return { success: true, escrow };
+}
+
+/**
+ * Lists all escrows for a given group, ordered by creation date (newest first).
+ *
+ * @param groupId  - The room/group ID
+ * @param supabase - Supabase client
+ */
+export async function listEscrowsByGroup(
+  groupId: string,
+  supabase: SupabaseClient
+): Promise<EscrowRecord[]> {
+  const { data, error } = await supabase
+    .from("escrows")
+    .select("*")
+    .eq("group_id", groupId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    logBlockchainOperation("error", "Failed to list escrows by group", {
+      groupId,
+      error: { type: "DBError", message: error.message },
+    });
+    return [];
+  }
+
+  return (data ?? []) as EscrowRecord[];
+}
+
+/**
+ * Lists all escrows where the given wallet is either initiator or beneficiary.
+ *
+ * @param walletAddress - Stellar public key
+ * @param supabase      - Supabase client
+ */
+export async function listEscrowsByWallet(
+  walletAddress: string,
+  supabase: SupabaseClient
+): Promise<EscrowRecord[]> {
+  const { data, error } = await supabase
+    .from("escrows")
+    .select("*")
+    .or(`initiator_wallet.eq.${walletAddress},beneficiary_wallet.eq.${walletAddress}`)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    logBlockchainOperation("error", "Failed to list escrows by wallet", {
+      error: { type: "DBError", message: error.message },
+    });
+    return [];
+  }
+
+  return (data ?? []) as EscrowRecord[];
+}
+
+/**
+ * Retrieves the full event history for an escrow.
+ *
+ * @param escrowId - UUID of the escrow
+ * @param supabase - Supabase client
+ */
+export async function getEscrowEvents(
+  escrowId: string,
+  supabase: SupabaseClient
+) {
+  const { data, error } = await supabase
+    .from("escrow_events")
+    .select("*")
+    .eq("escrow_id", escrowId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    logBlockchainOperation("error", "Failed to fetch escrow events", {
+      escrowId,
+      error: { type: "DBError", message: error.message },
+    });
+    return [];
+  }
+
+  return data ?? [];
+}

--- a/lib/blockchain/memo-service.ts
+++ b/lib/blockchain/memo-service.ts
@@ -1,0 +1,310 @@
+/**
+ * Memo Service — Group ID ↔ Transaction Mapping
+ *
+ * Responsibilities:
+ *  1. Submit a Stellar transaction whose memo encodes the group ID
+ *  2. Persist the groupId ↔ txHash mapping in the DB
+ *  3. Validate memo integrity on retrieval
+ *  4. Provide lookup helpers for controllers
+ */
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { loadStellarConfig, isConfigured, getExplorerUrl } from "./stellar-config";
+import { logBlockchainOperation, generateCorrelationId } from "./logger";
+import { buildGroupMemo, validateGroupMemo, MemoStrategy } from "./memo";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface MemoSubmissionResult {
+  success: boolean;
+  txHash?: string;
+  memoValue?: string;
+  memoType?: MemoStrategy;
+  explorerUrl?: string;
+  feeCharged?: string;
+  error?: string;
+}
+
+export interface MemoRecord {
+  id: string;
+  group_id: string;
+  tx_hash: string;
+  memo_value: string;
+  memo_type: MemoStrategy;
+  submitted_at: string;
+  verified_at: string | null;
+  is_valid: boolean;
+}
+
+export interface MemoValidationResult {
+  groupId: string;
+  txHash: string;
+  memoValue: string;
+  memoType: MemoStrategy;
+  isValid: boolean;
+  verifiedAt: string | null;
+}
+
+// ── Core service functions ────────────────────────────────────────────────────
+
+/**
+ * Submits a Stellar transaction with the group ID embedded in the memo field,
+ * then persists the groupId ↔ txHash mapping in the database.
+ *
+ * @param groupId   - The room/group ID to embed
+ * @param supabase  - Supabase client (service-role recommended for DB writes)
+ * @param userId    - Optional user ID for audit trail
+ * @param maxFee    - Optional custom fee in stroops
+ */
+export async function submitGroupMemoTransaction(
+  groupId: string,
+  supabase: SupabaseClient,
+  userId?: string,
+  maxFee?: string | number
+): Promise<MemoSubmissionResult> {
+  const correlationId = generateCorrelationId();
+
+  if (!isConfigured()) {
+    logBlockchainOperation(
+      "warn",
+      "Skipping memo transaction — Stellar config missing",
+      { groupId },
+      correlationId
+    );
+    return { success: false, error: "Stellar configuration not available" };
+  }
+
+  const config = loadStellarConfig();
+  if (!config) {
+    return { success: false, error: "Failed to load Stellar configuration" };
+  }
+
+  // Build the memo
+  const { memo, memoValue, memoType } = buildGroupMemo(groupId);
+
+  logBlockchainOperation(
+    "info",
+    "Submitting group memo transaction",
+    { groupId, memoValue, memoType, network: config.network },
+    correlationId
+  );
+
+  try {
+    const server = new StellarSdk.Horizon.Server(config.horizonUrl);
+    const sourceKeypair = StellarSdk.Keypair.fromSecret(config.sourceSecret);
+    const sourcePublicKey = sourceKeypair.publicKey();
+
+    const account = await Promise.race([
+      server.loadAccount(sourcePublicKey),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Timeout loading account")),
+          config.transactionTimeout
+        )
+      ),
+    ]);
+
+    const feeToUse = maxFee ? maxFee.toString() : StellarSdk.BASE_FEE;
+
+    const transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: feeToUse,
+      networkPassphrase:
+        config.network === "testnet"
+          ? StellarSdk.Networks.TESTNET
+          : StellarSdk.Networks.PUBLIC,
+    })
+      .addOperation(
+        StellarSdk.Operation.payment({
+          destination: sourcePublicKey, // self-payment — minimal cost
+          asset: StellarSdk.Asset.native(),
+          amount: "0.0000001",
+        })
+      )
+      .addMemo(memo)
+      .setTimeout(30)
+      .build();
+
+    transaction.sign(sourceKeypair);
+
+    const result = await Promise.race([
+      server.submitTransaction(transaction),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Transaction submission timeout")),
+          config.transactionTimeout
+        )
+      ),
+    ]);
+
+    const txHash = result.hash;
+    const feeCharged = (result as any).fee_charged?.toString() ?? feeToUse.toString();
+    const explorerUrl = getExplorerUrl(txHash, config.network);
+
+    logBlockchainOperation(
+      "info",
+      "Group memo transaction submitted",
+      { groupId, txHash, memoValue, memoType, feeCharged },
+      correlationId
+    );
+
+    // Persist the mapping in the DB
+    const { error: dbError } = await supabase.from("group_tx_memo_map").insert({
+      group_id: groupId,
+      tx_hash: txHash,
+      memo_value: memoValue,
+      memo_type: memoType,
+      is_valid: true,
+      verified_at: new Date().toISOString(),
+      created_by: userId ?? null,
+    });
+
+    if (dbError) {
+      // Non-fatal: log but still return success since the tx is on-chain
+      logBlockchainOperation(
+        "warn",
+        "Failed to persist memo mapping in DB",
+        { groupId, txHash, error: { type: "DBError", message: dbError.message } },
+        correlationId
+      );
+    }
+
+    return {
+      success: true,
+      txHash,
+      memoValue,
+      memoType,
+      explorerUrl,
+      feeCharged,
+    };
+  } catch (error: any) {
+    logBlockchainOperation(
+      "error",
+      "Group memo transaction failed",
+      {
+        groupId,
+        error: {
+          type: error.name ?? "UnknownError",
+          message: error.message ?? "Unknown error",
+        },
+      },
+      correlationId
+    );
+
+    return { success: false, error: error.message ?? "Transaction failed" };
+  }
+}
+
+/**
+ * Validates the memo integrity of a stored mapping record.
+ * Re-checks that the stored memo_value is consistent with the group_id.
+ *
+ * @param record - A row from group_tx_memo_map
+ * @returns MemoValidationResult
+ */
+export function validateMemoRecord(record: MemoRecord): MemoValidationResult {
+  const isValid = validateGroupMemo(
+    record.memo_value,
+    record.memo_type as MemoStrategy,
+    record.group_id
+  );
+
+  return {
+    groupId: record.group_id,
+    txHash: record.tx_hash,
+    memoValue: record.memo_value,
+    memoType: record.memo_type as MemoStrategy,
+    isValid,
+    verifiedAt: record.verified_at,
+  };
+}
+
+/**
+ * Looks up all memo mappings for a given group ID.
+ *
+ * @param groupId  - The room/group ID
+ * @param supabase - Supabase client
+ * @returns Array of MemoRecord rows, newest first
+ */
+export async function getMemosByGroupId(
+  groupId: string,
+  supabase: SupabaseClient
+): Promise<MemoRecord[]> {
+  const { data, error } = await supabase
+    .from("group_tx_memo_map")
+    .select("*")
+    .eq("group_id", groupId)
+    .order("submitted_at", { ascending: false });
+
+  if (error) {
+    logBlockchainOperation("error", "Failed to fetch memo mappings", {
+      groupId,
+      error: { type: "DBError", message: error.message },
+    });
+    return [];
+  }
+
+  return (data ?? []) as MemoRecord[];
+}
+
+/**
+ * Looks up the memo mapping for a specific transaction hash.
+ *
+ * @param txHash   - Stellar transaction hash
+ * @param supabase - Supabase client
+ * @returns MemoRecord or null
+ */
+export async function getMemoByTxHash(
+  txHash: string,
+  supabase: SupabaseClient
+): Promise<MemoRecord | null> {
+  const { data, error } = await supabase
+    .from("group_tx_memo_map")
+    .select("*")
+    .eq("tx_hash", txHash)
+    .maybeSingle();
+
+  if (error) {
+    logBlockchainOperation("error", "Failed to fetch memo by tx hash", {
+      transactionHash: txHash,
+      error: { type: "DBError", message: error.message },
+    });
+    return null;
+  }
+
+  return data as MemoRecord | null;
+}
+
+/**
+ * Validates memo integrity for all records belonging to a group and
+ * updates the is_valid flag in the DB accordingly.
+ *
+ * @param groupId  - The room/group ID
+ * @param supabase - Supabase client (service-role for updates)
+ * @returns Array of validation results
+ */
+export async function revalidateGroupMemos(
+  groupId: string,
+  supabase: SupabaseClient
+): Promise<MemoValidationResult[]> {
+  const records = await getMemosByGroupId(groupId, supabase);
+  const results: MemoValidationResult[] = [];
+
+  for (const record of records) {
+    const validation = validateMemoRecord(record);
+    results.push(validation);
+
+    // Update DB if validity changed
+    if (validation.isValid !== record.is_valid) {
+      await supabase
+        .from("group_tx_memo_map")
+        .update({
+          is_valid: validation.isValid,
+          verified_at: new Date().toISOString(),
+        })
+        .eq("id", record.id);
+    }
+  }
+
+  return results;
+}

--- a/lib/blockchain/memo-validation.ts
+++ b/lib/blockchain/memo-validation.ts
@@ -1,0 +1,230 @@
+/**
+ * Memo Validation Middleware
+ *
+ * Provides request-level validation for memo-related payloads before
+ * they reach controllers. Checks:
+ *  - Presence of required fields (groupId, txHash)
+ *  - Group ID existence in the DB
+ *  - Memo value integrity (format + DB record consistency)
+ *  - Memo type validity
+ */
+
+import { NextResponse } from "next/server";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { validateGroupMemo, getMemoStrategy, STELLAR_MEMO_TEXT_MAX_BYTES } from "./memo";
+import { getMemoByTxHash, getMemosByGroupId } from "./memo-service";
+
+export type MemoValidationError =
+  | { valid: false; response: NextResponse }
+  | { valid: true };
+
+/**
+ * Validates that a groupId is non-empty and exists in the rooms table.
+ */
+export async function validateGroupIdExists(
+  groupId: string,
+  supabase: SupabaseClient
+): Promise<MemoValidationError> {
+  if (!groupId || typeof groupId !== "string" || groupId.trim() === "") {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        { error: "groupId is required and must be a non-empty string" },
+        { status: 400 }
+      ),
+    };
+  }
+
+  const { data, error } = await supabase
+    .from("rooms")
+    .select("id")
+    .eq("id", groupId)
+    .maybeSingle();
+
+  if (error) {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        { error: "Failed to validate group ID" },
+        { status: 500 }
+      ),
+    };
+  }
+
+  if (!data) {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        { error: `Group '${groupId}' does not exist` },
+        { status: 404 }
+      ),
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Validates a memo value against a known group ID.
+ * Checks format correctness and byte-length constraints.
+ */
+export function validateMemoValue(
+  memoValue: string,
+  memoType: string,
+  groupId: string
+): MemoValidationError {
+  if (!memoValue || typeof memoValue !== "string") {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        { error: "memoValue is required" },
+        { status: 400 }
+      ),
+    };
+  }
+
+  if (!["text", "hash", "id", "return"].includes(memoType)) {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        { error: "memoType must be one of: text, hash, id, return" },
+        { status: 400 }
+      ),
+    };
+  }
+
+  // For text memos, enforce byte-length limit
+  if (memoType === "text") {
+    const byteLen = Buffer.byteLength(memoValue, "utf8");
+    if (byteLen > STELLAR_MEMO_TEXT_MAX_BYTES) {
+      return {
+        valid: false,
+        response: NextResponse.json(
+          {
+            error: `Memo text exceeds ${STELLAR_MEMO_TEXT_MAX_BYTES}-byte limit (got ${byteLen} bytes)`,
+          },
+          { status: 400 }
+        ),
+      };
+    }
+  }
+
+  // Validate memo integrity against the group ID
+  if (memoType === "text" || memoType === "hash") {
+    const isValid = validateGroupMemo(
+      memoValue,
+      memoType as "text" | "hash",
+      groupId
+    );
+    if (!isValid) {
+      return {
+        valid: false,
+        response: NextResponse.json(
+          {
+            error: "Memo value does not match the expected format for this group ID",
+            hint:
+              memoType === "text"
+                ? `Expected: grp:${groupId}`
+                : "Expected: SHA-256 hex of the group ID",
+          },
+          { status: 422 }
+        ),
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Validates that a txHash has a corresponding memo record in the DB
+ * and that the record's memo is consistent with the given groupId.
+ */
+export async function validateTxMemoRecord(
+  txHash: string,
+  groupId: string,
+  supabase: SupabaseClient
+): Promise<MemoValidationError> {
+  if (!txHash || typeof txHash !== "string" || txHash.trim() === "") {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        { error: "txHash is required" },
+        { status: 400 }
+      ),
+    };
+  }
+
+  const record = await getMemoByTxHash(txHash, supabase);
+
+  if (!record) {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        { error: `No memo record found for transaction '${txHash}'` },
+        { status: 404 }
+      ),
+    };
+  }
+
+  if (record.group_id !== groupId) {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        {
+          error: "Transaction memo is linked to a different group ID",
+          expected: groupId,
+          found: record.group_id,
+        },
+        { status: 409 }
+      ),
+    };
+  }
+
+  if (!record.is_valid) {
+    return {
+      valid: false,
+      response: NextResponse.json(
+        { error: "Memo record exists but failed integrity validation" },
+        { status: 422 }
+      ),
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Checks whether a group already has at least one valid memo transaction.
+ * Useful to prevent duplicate submissions.
+ */
+export async function groupHasValidMemo(
+  groupId: string,
+  supabase: SupabaseClient
+): Promise<boolean> {
+  const records = await getMemosByGroupId(groupId, supabase);
+  return records.some((r) => r.is_valid);
+}
+
+/**
+ * Determines the recommended memo strategy for a group ID and returns
+ * a human-readable explanation. Useful for client-side guidance.
+ */
+export function getMemoStrategyInfo(groupId: string): {
+  strategy: "text" | "hash";
+  explanation: string;
+  byteLength: number;
+} {
+  const candidate = `grp:${groupId}`;
+  const byteLength = Buffer.byteLength(candidate, "utf8");
+  const strategy = getMemoStrategy(groupId);
+
+  return {
+    strategy,
+    byteLength,
+    explanation:
+      strategy === "text"
+        ? `Group ID fits in 28 bytes as text memo: "${candidate}"`
+        : `Group ID (${byteLength} bytes) exceeds 28-byte limit; SHA-256 hash memo will be used`,
+  };
+}

--- a/lib/blockchain/memo.ts
+++ b/lib/blockchain/memo.ts
@@ -1,0 +1,127 @@
+/**
+ * Stellar Memo — Group ID Utilities
+ *
+ * Stellar's native memo field supports several types:
+ *   - MEMO_TEXT  : UTF-8 string, max 28 bytes
+ *   - MEMO_HASH  : 32-byte hash (opaque binary)
+ *   - MEMO_ID    : uint64 integer
+ *   - MEMO_RETURN: 32-byte hash (return payment)
+ *
+ * We use MEMO_TEXT for human-readable group references and MEMO_HASH
+ * when the group ID exceeds 28 bytes (we hash it to a fixed 32 bytes).
+ *
+ * Memo format for text:  "grp:<groupId>"  (prefix makes intent clear)
+ * Memo format for hash:  SHA-256(groupId) as raw 32-byte Buffer
+ */
+
+import { createHash } from "crypto";
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+/** Maximum byte length for a Stellar MEMO_TEXT value */
+export const STELLAR_MEMO_TEXT_MAX_BYTES = 28;
+
+/** Prefix used to namespace group memos */
+const GROUP_MEMO_PREFIX = "grp:";
+
+export type MemoStrategy = "text" | "hash";
+
+export interface GroupMemoResult {
+  memo: StellarSdk.Memo;
+  memoValue: string;   // human-readable representation stored in DB
+  memoType: MemoStrategy;
+}
+
+/**
+ * Builds a Stellar Memo that encodes the given groupId.
+ *
+ * Strategy selection:
+ *  - If "grp:<groupId>" fits within 28 bytes → MEMO_TEXT
+ *  - Otherwise → MEMO_HASH (SHA-256 of the groupId, 32 bytes)
+ *
+ * @param groupId - The group/room ID to embed
+ * @returns GroupMemoResult with the Memo object and metadata for DB storage
+ */
+export function buildGroupMemo(groupId: string): GroupMemoResult {
+  const candidate = `${GROUP_MEMO_PREFIX}${groupId}`;
+  const byteLength = Buffer.byteLength(candidate, "utf8");
+
+  if (byteLength <= STELLAR_MEMO_TEXT_MAX_BYTES) {
+    return {
+      memo: StellarSdk.Memo.text(candidate),
+      memoValue: candidate,
+      memoType: "text",
+    };
+  }
+
+  // Fall back to MEMO_HASH: SHA-256 of the groupId (32 bytes)
+  const hashBuffer = createHash("sha256").update(groupId, "utf8").digest();
+  return {
+    memo: StellarSdk.Memo.hash(hashBuffer.toString("hex")),
+    memoValue: hashBuffer.toString("hex"),
+    memoType: "hash",
+  };
+}
+
+/**
+ * Extracts the group ID from a raw memo value stored in the DB.
+ *
+ * For text memos: strips the "grp:" prefix.
+ * For hash memos: returns the hex string as-is (cannot reverse a hash).
+ *
+ * @param memoValue - The stored memo value
+ * @param memoType  - The memo type ("text" | "hash")
+ * @returns The group ID string, or null if the memo doesn't match our format
+ */
+export function extractGroupIdFromMemo(
+  memoValue: string,
+  memoType: MemoStrategy
+): string | null {
+  if (memoType === "text") {
+    if (memoValue.startsWith(GROUP_MEMO_PREFIX)) {
+      return memoValue.slice(GROUP_MEMO_PREFIX.length);
+    }
+    return null;
+  }
+
+  // For hash memos we cannot reverse, so return the hash itself
+  return memoValue;
+}
+
+/**
+ * Validates that a memo value is consistent with the expected group ID.
+ *
+ * For text memos: checks the "grp:<groupId>" format.
+ * For hash memos: recomputes SHA-256(groupId) and compares.
+ *
+ * @param memoValue - The memo value to validate
+ * @param memoType  - The memo type
+ * @param groupId   - The expected group ID
+ * @returns true if the memo is valid for the given group
+ */
+export function validateGroupMemo(
+  memoValue: string,
+  memoType: MemoStrategy,
+  groupId: string
+): boolean {
+  if (memoType === "text") {
+    return memoValue === `${GROUP_MEMO_PREFIX}${groupId}`;
+  }
+
+  // Hash memo: recompute and compare
+  const expected = createHash("sha256").update(groupId, "utf8").digest("hex");
+  return memoValue === expected;
+}
+
+/**
+ * Determines the appropriate memo strategy for a given group ID without
+ * building the full Memo object. Useful for pre-flight checks.
+ *
+ * @param groupId - The group ID to evaluate
+ * @returns "text" if it fits in 28 bytes, "hash" otherwise
+ */
+export function getMemoStrategy(groupId: string): MemoStrategy {
+  const candidate = `${GROUP_MEMO_PREFIX}${groupId}`;
+  return Buffer.byteLength(candidate, "utf8") <= STELLAR_MEMO_TEXT_MAX_BYTES
+    ? "text"
+    : "hash";
+}

--- a/scripts/011_group_tx_memo_map.sql
+++ b/scripts/011_group_tx_memo_map.sql
@@ -1,0 +1,46 @@
+-- Migration 011: Group ↔ Transaction memo mapping table
+-- Stores the mapping between group IDs and Stellar transaction IDs
+-- for quick lookup and memo integrity validation.
+
+create table if not exists public.group_tx_memo_map (
+  id            uuid primary key default gen_random_uuid(),
+  group_id      text not null references public.rooms(id) on delete cascade,
+  tx_hash       text not null,
+  memo_value    text not null,          -- the exact memo text stored on-chain (≤28 bytes)
+  memo_type     text not null default 'text' check (memo_type in ('text', 'hash', 'id', 'return')),
+  submitted_at  timestamp with time zone default timezone('utc', now()) not null,
+  verified_at   timestamp with time zone,
+  is_valid      boolean default false not null,
+  created_by    uuid references auth.users(id) on delete set null,
+
+  -- A group can have multiple transactions (e.g. updates), but each tx_hash is unique
+  unique (tx_hash)
+);
+
+create index if not exists group_tx_memo_map_group_id_idx on public.group_tx_memo_map(group_id);
+create index if not exists group_tx_memo_map_tx_hash_idx  on public.group_tx_memo_map(tx_hash);
+
+alter table public.group_tx_memo_map enable row level security;
+
+-- Authenticated users can read memo mappings for rooms they are members of
+create policy "Members can view memo mappings"
+  on public.group_tx_memo_map for select
+  using (
+    exists (
+      select 1 from public.room_members rm
+      where rm.room_id = group_tx_memo_map.group_id
+        and rm.user_id = auth.uid()
+        and rm.removed_at is null
+    )
+    or exists (
+      select 1 from public.rooms r
+      where r.id = group_tx_memo_map.group_id
+        and r.is_private = false
+    )
+  );
+
+-- Only service role can insert / update (done via API with service key)
+create policy "Service role can manage memo mappings"
+  on public.group_tx_memo_map for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');

--- a/scripts/012_escrow_tables.sql
+++ b/scripts/012_escrow_tables.sql
@@ -1,0 +1,85 @@
+-- Migration 012: Escrow lifecycle tables
+-- Supports create / fund / release / refund / dispute operations.
+
+-- ── Escrow accounts ──────────────────────────────────────────────────────────
+create table if not exists public.escrows (
+  id                  uuid primary key default gen_random_uuid(),
+  group_id            text not null references public.rooms(id) on delete restrict,
+  initiator_wallet    text not null,          -- Stellar public key of the creator
+  beneficiary_wallet  text not null,          -- Stellar public key of the recipient
+  amount_xlm         numeric(20, 7) not null check (amount_xlm > 0),
+  asset_code         text not null default 'XLM',
+  asset_issuer       text,                    -- null for native XLM
+  status             text not null default 'pending'
+                       check (status in ('pending','funded','released','refunded','disputed','resolved')),
+  memo_group_id      text,                    -- group ID embedded in the Stellar memo
+  fund_tx_hash       text,                    -- Stellar tx that funded the escrow
+  release_tx_hash    text,                    -- Stellar tx that released funds
+  refund_tx_hash     text,                    -- Stellar tx that refunded funds
+  dispute_reason     text,
+  resolved_by        uuid references auth.users(id) on delete set null,
+  created_at         timestamp with time zone default timezone('utc', now()) not null,
+  funded_at          timestamp with time zone,
+  released_at        timestamp with time zone,
+  refunded_at        timestamp with time zone,
+  disputed_at        timestamp with time zone,
+  resolved_at        timestamp with time zone,
+  expires_at         timestamp with time zone  -- optional expiry for auto-refund
+);
+
+create index if not exists escrows_group_id_idx         on public.escrows(group_id);
+create index if not exists escrows_initiator_wallet_idx on public.escrows(initiator_wallet);
+create index if not exists escrows_status_idx           on public.escrows(status);
+
+alter table public.escrows enable row level security;
+
+-- Participants (initiator or beneficiary profile) can view their escrows
+create policy "Participants can view escrows"
+  on public.escrows for select
+  using (
+    exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid()
+        and (p.wallet_address = escrows.initiator_wallet
+             or p.wallet_address = escrows.beneficiary_wallet)
+    )
+  );
+
+-- Service role manages all escrow operations
+create policy "Service role manages escrows"
+  on public.escrows for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+-- ── Escrow event log ─────────────────────────────────────────────────────────
+create table if not exists public.escrow_events (
+  id          uuid primary key default gen_random_uuid(),
+  escrow_id   uuid not null references public.escrows(id) on delete cascade,
+  event_type  text not null
+                check (event_type in ('created','funded','released','refunded','disputed','resolved','error')),
+  tx_hash     text,
+  actor_wallet text,
+  metadata    jsonb default '{}'::jsonb,
+  created_at  timestamp with time zone default timezone('utc', now()) not null
+);
+
+create index if not exists escrow_events_escrow_id_idx on public.escrow_events(escrow_id);
+
+alter table public.escrow_events enable row level security;
+
+create policy "Participants can view escrow events"
+  on public.escrow_events for select
+  using (
+    exists (
+      select 1 from public.escrows e
+      join public.profiles p on p.id = auth.uid()
+      where e.id = escrow_events.escrow_id
+        and (p.wallet_address = e.initiator_wallet
+             or p.wallet_address = e.beneficiary_wallet)
+    )
+  );
+
+create policy "Service role manages escrow events"
+  on public.escrow_events for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');

--- a/types/blockchain.ts
+++ b/types/blockchain.ts
@@ -50,5 +50,10 @@ export interface GroupCreationResponse {
     transactionHash?: string;
     feeCharged?: string;
     explorerUrl?: string;
+    memo?: {
+      txHash: string;
+      memoValue: string | null;
+      memoType: string | null;
+    };
   };
 }

--- a/types/escrow.ts
+++ b/types/escrow.ts
@@ -1,0 +1,115 @@
+/**
+ * Escrow type definitions
+ *
+ * These types mirror the DB schema in scripts/012_escrow_tables.sql
+ * and define the public API surface of the escrow service layer.
+ */
+
+// ── Status ────────────────────────────────────────────────────────────────────
+
+export type EscrowStatus =
+  | "pending"    // created, not yet funded
+  | "funded"     // funds locked on-chain
+  | "released"   // funds sent to beneficiary
+  | "refunded"   // funds returned to initiator
+  | "disputed"   // dispute raised, awaiting resolution
+  | "resolved";  // dispute resolved
+
+export type EscrowEventType =
+  | "created"
+  | "funded"
+  | "released"
+  | "refunded"
+  | "disputed"
+  | "resolved"
+  | "error";
+
+// ── DB row shapes ─────────────────────────────────────────────────────────────
+
+export interface EscrowRecord {
+  id: string;
+  group_id: string;
+  initiator_wallet: string;
+  beneficiary_wallet: string;
+  amount_xlm: number;
+  asset_code: string;
+  asset_issuer: string | null;
+  status: EscrowStatus;
+  memo_group_id: string | null;
+  fund_tx_hash: string | null;
+  release_tx_hash: string | null;
+  refund_tx_hash: string | null;
+  dispute_reason: string | null;
+  resolved_by: string | null;
+  created_at: string;
+  funded_at: string | null;
+  released_at: string | null;
+  refunded_at: string | null;
+  disputed_at: string | null;
+  resolved_at: string | null;
+  expires_at: string | null;
+}
+
+export interface EscrowEventRecord {
+  id: string;
+  escrow_id: string;
+  event_type: EscrowEventType;
+  tx_hash: string | null;
+  actor_wallet: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+// ── Service input/output types ────────────────────────────────────────────────
+
+export interface CreateEscrowInput {
+  groupId: string;
+  initiatorWallet: string;
+  beneficiaryWallet: string;
+  amountXlm: number;
+  assetCode?: string;       // defaults to "XLM"
+  assetIssuer?: string;     // null for native XLM
+  expiresAt?: string;       // ISO-8601 datetime
+}
+
+export interface FundEscrowInput {
+  escrowId: string;
+  fundTxHash: string;       // Stellar tx hash that transferred funds
+  actorWallet: string;
+}
+
+export interface ReleaseEscrowInput {
+  escrowId: string;
+  actorWallet: string;      // must be initiator or authorised party
+  maxFee?: string | number;
+}
+
+export interface RefundEscrowInput {
+  escrowId: string;
+  actorWallet: string;
+  maxFee?: string | number;
+}
+
+export interface DisputeEscrowInput {
+  escrowId: string;
+  actorWallet: string;
+  reason: string;
+}
+
+export interface ResolveDisputeInput {
+  escrowId: string;
+  resolverUserId: string;   // Supabase user ID of the resolver
+  releaseToInitiator: boolean; // true → refund, false → release to beneficiary
+  maxFee?: string | number;
+}
+
+// ── Service result types ──────────────────────────────────────────────────────
+
+export interface EscrowResult {
+  success: boolean;
+  escrow?: EscrowRecord;
+  txHash?: string;
+  explorerUrl?: string;
+  feeCharged?: string;
+  error?: string;
+}


### PR DESCRIPTION
closes #51 
closes #135 
## Summary

Implements two features for on-chain group identification and escrow management.

## Feature A — Stellar Memo Group ID Linking

Leverages Stellar's native memo field to embed group IDs in on-chain transactions, enabling lightweight group identification without custom contracts.

- Auto-selects MEMO_TEXT (`grp:<id>`) for IDs ≤28 bytes, falls back to MEMO_HASH (SHA-256) for longer IDs
- Persists `groupId ↔ txHash` mapping in new `group_tx_memo_map` table
- Validation middleware checks memo integrity before processing
- Room creation now fires a dedicated memo transaction alongside the metadata hash tx
- New endpoints: `POST /api/stellar/memo`, `GET /api/stellar/memo`, `POST /api/stellar/memo/validate`

## Feature B — Escrow Lifecycle Service Layer

Full service layer abstracting all blockchain logic away from controllers.

- `createEscrow` → `fundEscrow` → `releaseEscrow`
- `fundEscrow` → `refundEscrow` (beneficiary anytime; initiator after expiry)
- `fundEscrow` → `disputeEscrow` → `resolveDispute` (extensible to DAO voting)
- Full audit trail via `escrow_events` table
- New endpoints under `/api/escrow/[escrowId]/{fund,release,refund,dispute,resolve}`

## Files Changed
- 16 new files, 2 modified
- 2 new SQL migrations (011, 012)
- Zero TypeScript errors



