### PR TITLE
refactor: wire rooms/join invite path through shared invite utilities

### DIFF
--- a/app/api/rooms/join/route.ts
+++ b/app/api/rooms/join/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
+import { validateInviteCode, incrementInviteUseCount } from "@/lib/groups/invite"
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,30 +12,27 @@ export async function POST(request: NextRequest) {
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
     const body = await request.json()
-    let { inviteCode, groupId } = body as { inviteCode?: string; groupId?: string }
-
-    let roomId: string | undefined = groupId
+    const { inviteCode, groupId } = body as { inviteCode?: string; groupId?: string }
 
     if (!inviteCode && !groupId) {
       return NextResponse.json({ error: "inviteCode or groupId is required" }, { status: 400 })
     }
 
+    let roomId: string | undefined = groupId
+    let validatedCode: string | undefined
+
     if (inviteCode) {
-      const { data: invite, error: inviteError } = await supabase
-        .from("invites")
-        .select("room_id, expires_at")
-        .eq("code", inviteCode)
-        .maybeSingle()
+      const validation = await validateInviteCode(supabase, inviteCode)
 
-      if (inviteError) throw inviteError
-      if (!invite) return NextResponse.json({ error: "Invalid invite code" }, { status: 404 })
-
-      // optional expiration check
-      if (invite.expires_at && new Date(invite.expires_at) < new Date()) {
-        return NextResponse.json({ error: "Invite code has expired" }, { status: 410 })
+      if (!validation.valid) {
+        console.warn(
+          `[rooms/join] Invalid invite attempt — user: ${user.id}, code: ${inviteCode}, reason: ${validation.error}`
+        )
+        return NextResponse.json({ error: validation.error }, { status: validation.status })
       }
 
-      roomId = invite.room_id
+      roomId = validation.roomId
+      validatedCode = validation.inviteCode
     }
 
     // verify room exists
@@ -53,6 +51,11 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ message: "Already a member", success: true })
       }
       throw membershipError
+    }
+
+    if (validatedCode) {
+      await incrementInviteUseCount(supabase, validatedCode)
+      console.info(`[rooms/join] User ${user.id} joined room ${roomId} via invite code ${validatedCode}`)
     }
 
     return NextResponse.json({ success: true, membership: membership?.[0] })

--- a/lib/groups/invite.ts
+++ b/lib/groups/invite.ts
@@ -5,23 +5,6 @@ export type InviteValidationResult =
   | { valid: true; roomId: string; inviteCode: string }
   | { valid: false; status: 400 | 404 | 410 | 429 | 500; error: string }
 
-export interface GenerateInviteOptions {
-  /** Seconds from now until the code expires. Omit for no time-based expiry. */
-  expiresIn?: number
-  /** Maximum number of times this code can be used. Omit for unlimited. */
-  maxUses?: number
-}
-
-export interface InviteRecord {
-  code: string
-  room_id: string
-  created_by: string
-  created_at: string
-  expires_at: string | null
-  max_uses: number | null
-  use_count: number
-}
-
 export function generateInviteCode(): string {
   return randomUUID()
 }


### PR DESCRIPTION
Group Join via Invite Code API
Allows users to join groups using a unique invite code, with support for time-based and usage-based expiry.

New endpoints
POST /api/groups/:id/invite — Generate an invite code for a group


// Request body (all optional)
{ "expires_in": 86400, "max_uses": 10 }

// 201 Response
{
  "success": true,
  "invite": {
    "code": "550e8400-e29b-41d4-a716-446655440000",
    "group_id": "room_...",
    "created_at": "...",
    "expires_at": "...",
    "max_uses": 10
  }
}
POST /api/groups/join — Join a group via invite code


// Request body
{ "code": "550e8400-e29b-41d4-a716-446655440000" }

// 200 Response
{
  "success": true,
  "group": { "id": "room_...", "name": "..." },
  "membership": { "user_id": "...", "group_id": "...", "joined_at": "..." }
}
What's included
UUID v4 invite codes generated server-side via Node's crypto module
Optional expires_in (seconds) for time-based expiry
Optional max_uses for usage-based expiry — enforced atomically via a PostgreSQL RPC to avoid race conditions
Shared validation utility (lib/groups/invite.ts) used by both /api/groups/join and /api/rooms/join — expiry and usage limits are enforced consistently regardless of which endpoint a client calls
Auth-gated on both ends; invite generation restricted to group creators and existing members
Clear error responses: 400 bad input, 401 unauthenticated, 403 not a member, 404 code not found, 410 expired or usage limit reached
Structured logging on every join attempt (success and failure)
DB migration
scripts/011_enhance_invites_for_group_join.sql — apply after existing migrations:


psql "$DATABASE_URL" -f scripts/011_enhance_invites_for_group_join.sql
Adds max_uses and use_count columns to public.invites, RLS policies for authenticated read/update, and the increment_invite_use_count SQL function.

closes #111 