### PR TITLE
Added on-chain Stellar group ownership and owner-validated room update endpoint

### DIFF
--- a/app/api/rooms/[roomId]/route.ts
+++ b/app/api/rooms/[roomId]/route.ts
@@ -1,0 +1,188 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { consumeNonce, verifyWalletSignature } from "@/lib/auth/stellar-verify";
+import { validateRequiredFields, validateStellarAddress } from "@/lib/auth/validation";
+import { resolveRoomOwnerWallet } from "@/lib/auth/wallet-owner";
+import { computeHash } from "@/lib/blockchain/metadata-hash";
+import { submitMetadataHash, getTransactionExplorerUrl } from "@/lib/blockchain/stellar-service";
+import { GroupMetadata } from "@/types/blockchain";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+) {
+  const { roomId } = await params;
+
+  try {
+    const supabase = await createClient();
+    const { data: room, error } = await supabase
+      .from("rooms")
+      .select("*")
+      .eq("id", roomId)
+      .single();
+
+    if (error || !room) {
+      return NextResponse.json({ error: "Room not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ room }, { status: 200 });
+  } catch (error) {
+    console.error("[rooms/[roomId]] GET error:", error);
+    return NextResponse.json({ error: "Failed to fetch room" }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> },
+) {
+  const { roomId } = await params;
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { walletAddress, signature, name, description, is_private } = body ?? {};
+
+    const errors = validateRequiredFields(body ?? {}, ["walletAddress", "signature"]);
+    if (errors.length > 0) {
+      return NextResponse.json(
+        { error: errors.map((error) => error.message).join(", ") },
+        { status: 400 },
+      );
+    }
+
+    if (!validateStellarAddress(walletAddress)) {
+      return NextResponse.json({ error: "Invalid wallet address" }, { status: 400 });
+    }
+
+    const { data: room, error: roomError } = await supabase
+      .from("rooms")
+      .select("id, name, description, is_private, created_by, owner_wallet, stellar_tx_hash, metadata_hash, memo_group_id")
+      .eq("id", roomId)
+      .single();
+
+    if (roomError || !room) {
+      return NextResponse.json({ error: "Room not found" }, { status: 404 });
+    }
+
+    const ownerWallet = await resolveRoomOwnerWallet(supabase, room);
+    if (!ownerWallet) {
+      return NextResponse.json({ error: "Cannot resolve room owner wallet" }, { status: 400 });
+    }
+
+    if (ownerWallet !== walletAddress) {
+      return NextResponse.json({ error: "Unauthorized: wallet does not own this room" }, { status: 403 });
+    }
+
+    const nonce = await consumeNonce(walletAddress);
+    if (!nonce) {
+      return NextResponse.json(
+        { error: "Nonce not found or expired. Request a new nonce." },
+        { status: 401 },
+      );
+    }
+
+    const isValidSignature = verifyWalletSignature(walletAddress, nonce, signature);
+    if (!isValidSignature) {
+      return NextResponse.json({ error: "Signature verification failed" }, { status: 401 });
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (typeof name === "string" && name.trim().length > 0) {
+      updates.name = name.trim();
+    }
+    if (typeof description === "string") {
+      updates.description = description.trim();
+    }
+    if (typeof is_private === "boolean") {
+      updates.is_private = is_private;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: "No valid update fields provided" }, { status: 400 });
+    }
+
+    const { data: updatedRoom, error: updateError } = await supabase
+      .from("rooms")
+      .update(updates)
+      .eq("id", roomId)
+      .select()
+      .single();
+
+    if (updateError || !updatedRoom) {
+      throw updateError || new Error("Failed to update room");
+    }
+
+    const metadata: GroupMetadata = {
+      id: updatedRoom.id,
+      name: updatedRoom.name,
+      description: updatedRoom.description,
+      created_by: updatedRoom.created_by,
+      created_at: updatedRoom.created_at,
+      is_private: updatedRoom.is_private,
+      owner_wallet: ownerWallet,
+    };
+
+    const currentMetadataHash = computeHash(metadata);
+    let stellarTxHash = updatedRoom.stellar_tx_hash ?? null;
+    let metadataHash = updatedRoom.metadata_hash ?? null;
+    let memoGroupId = updatedRoom.memo_group_id ?? null;
+    let blockchainSubmitted = false;
+    let explorerUrl: string | null = null;
+    let actualFeeCharged: string | null = null;
+
+    try {
+      const result = await submitMetadataHash(roomId, currentMetadataHash);
+      if (result.success && result.transactionHash) {
+        stellarTxHash = result.transactionHash;
+        metadataHash = currentMetadataHash;
+        actualFeeCharged = result.feeCharged || null;
+        blockchainSubmitted = true;
+        explorerUrl = getTransactionExplorerUrl(result.transactionHash);
+        memoGroupId = result.memoGroupId ?? null;
+
+        await supabase
+          .from("rooms")
+          .update({
+            stellar_tx_hash: stellarTxHash,
+            metadata_hash: metadataHash,
+            blockchain_submitted_at: new Date().toISOString(),
+            memo_group_id: result.memoGroupId ?? null,
+          })
+          .eq("id", roomId);
+      }
+    } catch (blockchainError: any) {
+      console.error("[rooms/[roomId]] PATCH blockchain submission error:", blockchainError);
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        room: {
+          ...updatedRoom,
+          stellar_tx_hash: stellarTxHash,
+          metadata_hash: metadataHash,
+          memo_group_id: memoGroupId,
+        },
+        blockchain: {
+          submitted: blockchainSubmitted,
+          transactionHash: stellarTxHash || undefined,
+          feeCharged: actualFeeCharged || undefined,
+          explorerUrl: explorerUrl || undefined,
+          memoGroupId: memoGroupId || undefined,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("[rooms/[roomId]] PATCH error:", error);
+    return NextResponse.json({ error: "Failed to update room" }, { status: 500 });
+  }
+}

--- a/app/api/rooms/[roomId]/verify/route.ts
+++ b/app/api/rooms/[roomId]/verify/route.ts
@@ -41,6 +41,7 @@ export async function GET(
       created_by: room.created_by,
       created_at: room.created_at,
       is_private: room.is_private,
+      owner_wallet: room.owner_wallet ?? null,
     };
 
     // Compute current metadata hash

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -97,6 +97,14 @@ export async function POST(request: NextRequest) {
     const createdAt = new Date().toISOString();
 
     // Insert group into database first
+    const walletAddress = (user as any)?.user_metadata?.wallet_address;
+    if (!walletAddress) {
+      return NextResponse.json(
+        { error: "Cannot determine owner wallet from authenticated session" },
+        { status: 401 },
+      );
+    }
+
     const { data, error } = await supabase
       .from("rooms")
       .insert({
@@ -105,6 +113,7 @@ export async function POST(request: NextRequest) {
         description,
         is_private: is_private || false,
         created_by: user.id,
+        owner_wallet: walletAddress,
       })
       .select();
 
@@ -120,6 +129,7 @@ export async function POST(request: NextRequest) {
       created_by: room.created_by,
       created_at: room.created_at,
       is_private: room.is_private,
+      owner_wallet: room.owner_wallet,
     };
 
     // Compute metadata hash
@@ -236,6 +246,7 @@ export async function POST(request: NextRequest) {
       {
         room: {
           ...room,
+          owner_wallet: walletAddress,
           stellar_tx_hash: stellarTxHash,
           metadata_hash: metadataHash,
           memo_group_id: memoGroupId,

--- a/lib/auth/wallet-owner.ts
+++ b/lib/auth/wallet-owner.ts
@@ -1,0 +1,43 @@
+import { validateStellarAddress } from "./validation";
+
+/**
+ * Extracts the wallet address from Supabase user metadata.
+ */
+export function getWalletAddressFromUser(user: any): string | null {
+  if (!user || typeof user !== "object") return null;
+
+  const metadata = (user as any).user_metadata as Record<string, unknown> | undefined;
+  if (!metadata || typeof metadata.wallet_address !== "string") return null;
+
+  const walletAddress = metadata.wallet_address;
+  return validateStellarAddress(walletAddress) ? walletAddress : null;
+}
+
+/**
+ * Resolves the owner wallet address for a room, preferring the explicit room field.
+ * Falls back to the creator's profile wallet address when available.
+ */
+export async function resolveRoomOwnerWallet(
+  supabase: any,
+  room: { owner_wallet?: string | null; created_by?: string }
+): Promise<string | null> {
+  if (room?.owner_wallet && validateStellarAddress(room.owner_wallet)) {
+    return room.owner_wallet;
+  }
+
+  if (!room?.created_by) {
+    return null;
+  }
+
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select("wallet_address")
+    .eq("id", room.created_by)
+    .maybeSingle();
+
+  if (error || !profile || typeof profile.wallet_address !== "string") {
+    return null;
+  }
+
+  return validateStellarAddress(profile.wallet_address) ? profile.wallet_address : null;
+}

--- a/scripts/012_add_room_owner_wallet.sql
+++ b/scripts/012_add_room_owner_wallet.sql
@@ -1,0 +1,10 @@
+-- Migration: Add owner_wallet to rooms for wallet-based group ownership
+-- This stores the Stellar wallet address that owns the room.
+
+ALTER TABLE public.rooms
+ADD COLUMN IF NOT EXISTS owner_wallet text NULL;
+
+COMMENT ON COLUMN public.rooms.owner_wallet IS
+  'Stellar wallet address that owns this chat room/group';
+
+CREATE INDEX IF NOT EXISTS rooms_owner_wallet_idx ON public.rooms(owner_wallet);

--- a/types/blockchain.ts
+++ b/types/blockchain.ts
@@ -7,6 +7,7 @@ export interface GroupMetadata {
   created_by: string;
   created_at: string;
   is_private: boolean;
+  owner_wallet?: string | null;
 }
 
 export interface StellarTransactionResult {
@@ -46,6 +47,7 @@ export interface GroupCreationResponse {
     is_private: boolean;
     created_by: string;
     created_at: string;
+    owner_wallet?: string | null;
     stellar_tx_hash: string | null;
     metadata_hash?: string | null;
     blockchain_submitted_at?: string | null;


### PR DESCRIPTION
Close #39

# PR: Implement On-Chain Group Ownership

## Summary
This change ties group ownership to a Stellar wallet address and enforces that only the wallet owner can update group metadata.

## What changed
- Persisted `owner_wallet` on `rooms` during group creation
- Added `PATCH /api/rooms/[roomId]` endpoint to update room metadata
- Validates update requests by:
  - requiring `walletAddress` and `signature`
  - verifying the signature against a one-time nonce
  - checking that the wallet address matches the room owner
- Included `owner_wallet` in on-chain metadata hash verification
- Added DB migration to add `owner_wallet` column to `public.rooms`

## Testing
1. Apply migration: run `scripts/012_add_room_owner_wallet.sql` in Supabase
2. Create a group with a connected Stellar wallet
3. Confirm the new room record includes `owner_wallet`
4. Request a nonce via `/api/auth/nonce`, sign it with the owner wallet, then call `PATCH /api/rooms/<roomId>` with `walletAddress`, `signature`, and updated metadata
5. Confirm updates succeed only when the correct owner wallet and signature are provided, and fail otherwise
