### PR TITLE
135 On-Chain Audit Log for Group Events

### DIFF
--- a/app/api/groups/[id]/audit/route.ts
+++ b/app/api/groups/[id]/audit/route.ts
@@ -1,0 +1,122 @@
+import { createClient } from "@/lib/supabase/server"
+import { type NextRequest, NextResponse } from "next/server"
+import { getTransactionExplorerUrl } from "@/lib/blockchain/stellar-service"
+
+const EVENT_TYPES = new Set([
+  "group_created",
+  "member_joined",
+  "member_left",
+  "member_removed",
+])
+
+const STATUSES = new Set(["pending", "submitted", "failed"])
+
+function parsePositiveInteger(value: string | null, fallback: number): number {
+  if (!value) return fallback
+
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+type AuditEventRow = {
+  event_id: string
+  group_id: string
+  event_type: string
+  actor_user_id: string | null
+  target_user_id: string | null
+  transaction_hash: string | null
+  stellar_memo: string | null
+  metadata_hash: string
+  status: string
+  error_message: string | null
+  created_at: string
+  submitted_at: string | null
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { id: groupId } = await params
+    if (!groupId) {
+      return NextResponse.json({ error: "Group ID is required" }, { status: 400 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const page = parsePositiveInteger(searchParams.get("page"), 1)
+    const limit = Math.min(parsePositiveInteger(searchParams.get("limit"), 20), 100)
+    const eventType = searchParams.get("eventType")
+    const status = searchParams.get("status")
+
+    if (eventType && !EVENT_TYPES.has(eventType)) {
+      return NextResponse.json({ error: "Invalid eventType filter" }, { status: 400 })
+    }
+
+    if (status && !STATUSES.has(status)) {
+      return NextResponse.json({ error: "Invalid status filter" }, { status: 400 })
+    }
+
+    const from = (page - 1) * limit
+    const to = from + limit - 1
+
+    let query = supabase
+      .from("group_audit_events")
+      .select(
+        "event_id, group_id, event_type, actor_user_id, target_user_id, transaction_hash, stellar_memo, metadata_hash, status, error_message, created_at, submitted_at",
+        { count: "exact" }
+      )
+      .eq("group_id", groupId)
+      .order("created_at", { ascending: false })
+      .range(from, to)
+
+    if (eventType) {
+      query = query.eq("event_type", eventType)
+    }
+
+    if (status) {
+      query = query.eq("status", status)
+    }
+
+    const { data, error, count } = await query
+    if (error) throw error
+
+    return NextResponse.json({
+      auditTrail: ((data ?? []) as AuditEventRow[]).map((event) => ({
+        eventId: event.event_id,
+        groupId: event.group_id,
+        eventType: event.event_type,
+        actorUserId: event.actor_user_id,
+        targetUserId: event.target_user_id,
+        transactionHash: event.transaction_hash,
+        explorerUrl: event.transaction_hash
+          ? getTransactionExplorerUrl(event.transaction_hash)
+          : null,
+        stellarMemo: event.stellar_memo,
+        metadataHash: event.metadata_hash,
+        status: event.status,
+        error: event.error_message,
+        timestamp: event.created_at,
+        submittedAt: event.submitted_at,
+      })),
+      pagination: {
+        page,
+        limit,
+        total: count ?? 0,
+        hasMore: from + (data?.length ?? 0) < (count ?? 0),
+      },
+    })
+  } catch (error) {
+    console.error("[groups/audit] GET error:", error)
+    return NextResponse.json({ error: "Failed to fetch audit trail" }, { status: 500 })
+  }
+}

--- a/app/api/groups/join/route.ts
+++ b/app/api/groups/join/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 import { validateInviteCode, incrementInviteUseCount } from "@/lib/groups/invite"
+import { recordGroupAuditEvent } from "@/lib/blockchain/audit"
 
 export async function POST(request: NextRequest) {
   try {
@@ -66,6 +67,18 @@ export async function POST(request: NextRequest) {
       `[groups/join] User ${user.id} joined group ${roomId} via invite code ${inviteCode}`
     )
 
+    const auditEvent = await recordGroupAuditEvent({
+      supabase,
+      groupId: roomId,
+      eventType: "member_joined",
+      actorUserId: user.id,
+      targetUserId: user.id,
+      metadata: {
+        invite_code_used: inviteCode,
+        membership_id: membership.id,
+      },
+    })
+
     return NextResponse.json({
       success: true,
       group: { id: group.id, name: group.name },
@@ -74,6 +87,7 @@ export async function POST(request: NextRequest) {
         group_id: membership.room_id,
         joined_at: membership.joined_at,
       },
+      audit: auditEvent ?? undefined,
     })
   } catch (error) {
     console.error("[groups/join] POST /api/groups/join error:", error)

--- a/app/api/groups/join/route.ts
+++ b/app/api/groups/join/route.ts
@@ -1,47 +1,58 @@
-import { createClient } from "@/lib/supabase/server"
-import { type NextRequest, NextResponse } from "next/server"
-import { validateInviteCode, incrementInviteUseCount } from "@/lib/groups/invite"
-import { recordGroupAuditEvent } from "@/lib/blockchain/audit"
+import { createClient } from "@/lib/supabase/server";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  validateInviteCode,
+  incrementInviteUseCount,
+} from "@/lib/groups/invite";
+import { recordGroupAuditEvent } from "@/lib/blockchain/audit";
 
 export async function POST(request: NextRequest) {
   try {
-    const supabase = await createClient()
+    const supabase = await createClient();
 
     const {
       data: { user },
-    } = await supabase.auth.getUser()
+    } = await supabase.auth.getUser();
 
     if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json().catch(() => null)
+    const body = await request.json().catch(() => null);
     if (!body) {
-      return NextResponse.json({ error: "Request body is required" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Request body is required" },
+        { status: 400 },
+      );
     }
 
-    const { code } = body as { code?: string }
+    const { code } = body as { code?: string };
 
-    const validation = await validateInviteCode(supabase, code ?? "")
+    const validation = await validateInviteCode(supabase, code ?? "");
 
     if (!validation.valid) {
       console.warn(
-        `[groups/join] Invalid invite attempt — user: ${user.id}, code: ${code ?? "(none)"}, reason: ${validation.error}`
-      )
-      return NextResponse.json({ error: validation.error }, { status: validation.status })
+        `[groups/join] Invalid invite attempt — user: ${user.id}, code: ${
+          code ?? "(none)"
+        }, reason: ${validation.error}`,
+      );
+      return NextResponse.json(
+        { error: validation.error },
+        { status: validation.status },
+      );
     }
 
-    const { roomId, inviteCode } = validation
+    const { roomId, inviteCode } = validation;
 
     // Verify the group still exists
     const { data: group } = await supabase
       .from("rooms")
       .select("id, name")
       .eq("id", roomId)
-      .maybeSingle()
+      .maybeSingle();
 
     if (!group) {
-      return NextResponse.json({ error: "Group not found" }, { status: 404 })
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
     }
 
     // Insert membership record
@@ -49,23 +60,28 @@ export async function POST(request: NextRequest) {
       .from("room_members")
       .insert({ user_id: user.id, room_id: roomId })
       .select("user_id, room_id, joined_at")
-      .single()
+      .single();
 
     if (membershipError) {
       // Unique constraint violation — user is already a member
       if (membershipError.code === "23505") {
-        console.info(`[groups/join] User ${user.id} is already a member of group ${roomId}`)
-        return NextResponse.json({ success: true, message: "Already a member" })
+        console.info(
+          `[groups/join] User ${user.id} is already a member of group ${roomId}`,
+        );
+        return NextResponse.json({
+          success: true,
+          message: "Already a member",
+        });
       }
-      throw membershipError
+      throw membershipError;
     }
 
     // Atomically increment invite usage count (non-blocking on failure)
-    await incrementInviteUseCount(supabase, inviteCode)
+    await incrementInviteUseCount(supabase, inviteCode);
 
     console.info(
-      `[groups/join] User ${user.id} joined group ${roomId} via invite code ${inviteCode}`
-    )
+      `[groups/join] User ${user.id} joined group ${roomId} via invite code ${inviteCode}`,
+    );
 
     const auditEvent = await recordGroupAuditEvent({
       supabase,
@@ -75,9 +91,10 @@ export async function POST(request: NextRequest) {
       targetUserId: user.id,
       metadata: {
         invite_code_used: inviteCode,
-        membership_id: membership.id,
+        membership_user_id: membership.user_id,
+        membership_room_id: membership.room_id,
       },
-    })
+    });
 
     return NextResponse.json({
       success: true,
@@ -88,9 +105,12 @@ export async function POST(request: NextRequest) {
         joined_at: membership.joined_at,
       },
       audit: auditEvent ?? undefined,
-    })
+    });
   } catch (error) {
-    console.error("[groups/join] POST /api/groups/join error:", error)
-    return NextResponse.json({ error: "Failed to join group" }, { status: 500 })
+    console.error("[groups/join] POST /api/groups/join error:", error);
+    return NextResponse.json(
+      { error: "Failed to join group" },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server"
+import { recordGroupAuditEvent } from "@/lib/blockchain/audit"
 import {
   checkAndConsumeWalletMessageSlot,
   formatRateLimitWindow,
@@ -159,11 +160,27 @@ export async function POST(request: NextRequest) {
     }
 
     if (!membership) {
-      const { error: insertMemberErr } = await supabase.from("room_members").insert({
-        room_id,
-        user_id: user.id,
-      })
+      const { data: insertedMembership, error: insertMemberErr } = await supabase
+        .from("room_members")
+        .insert({
+          room_id,
+          user_id: user.id,
+        })
+        .select("id")
+        .single()
       if (insertMemberErr) throw insertMemberErr
+
+      await recordGroupAuditEvent({
+        supabase,
+        groupId: room_id,
+        eventType: "member_joined",
+        actorUserId: user.id,
+        targetUserId: user.id,
+        metadata: {
+          membership_id: insertedMembership?.id ?? null,
+          source: "message_send_auto_join",
+        },
+      })
     }
 
     const { data, error } = await supabase

--- a/app/api/rooms/[roomId]/members/route.ts
+++ b/app/api/rooms/[roomId]/members/route.ts
@@ -1,5 +1,11 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
+import { recordGroupAuditEvent } from "@/lib/blockchain/audit"
+
+type MemberRow = {
+  user_id: string
+  joined_at: string
+}
 
 export async function GET(
   request: NextRequest,
@@ -29,7 +35,7 @@ export async function GET(
     if (error) throw error
 
     return NextResponse.json({
-      members: (members ?? []).map((m) => ({
+      members: ((members ?? []) as MemberRow[]).map((m) => ({
         user_id: m.user_id,
         joined_at: m.joined_at,
         is_current_user: m.user_id === user.id,
@@ -38,5 +44,67 @@ export async function GET(
   } catch (error) {
     console.error("[rooms/members] GET error:", error)
     return NextResponse.json({ error: "Failed to fetch members" }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ roomId: string }> }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { roomId } = await params
+    if (!roomId) {
+      return NextResponse.json({ error: "roomId is required" }, { status: 400 })
+    }
+
+    const { data: membership, error: membershipError } = await supabase
+      .from("room_members")
+      .select("id, joined_at")
+      .eq("room_id", roomId)
+      .eq("user_id", user.id)
+      .is("removed_at", null)
+      .maybeSingle()
+
+    if (membershipError) throw membershipError
+    if (!membership) {
+      return NextResponse.json({ error: "Active membership not found" }, { status: 404 })
+    }
+
+    const { error: deleteError } = await supabase
+      .from("room_members")
+      .delete()
+      .eq("room_id", roomId)
+      .eq("user_id", user.id)
+
+    if (deleteError) throw deleteError
+
+    const auditEvent = await recordGroupAuditEvent({
+      supabase,
+      groupId: roomId,
+      eventType: "member_left",
+      actorUserId: user.id,
+      targetUserId: user.id,
+      metadata: {
+        membership_id: membership.id,
+        joined_at: membership.joined_at,
+      },
+    })
+
+    return NextResponse.json({
+      success: true,
+      message: "Left room",
+      audit: auditEvent ?? undefined,
+    })
+  } catch (error) {
+    console.error("[rooms/members] DELETE error:", error)
+    return NextResponse.json({ error: "Failed to leave room" }, { status: 500 })
   }
 }

--- a/app/api/rooms/[roomId]/vote-remove/route.ts
+++ b/app/api/rooms/[roomId]/vote-remove/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
+import { recordGroupAuditEvent } from "@/lib/blockchain/audit"
 
 export async function POST(
   request: NextRequest,
@@ -95,10 +96,24 @@ export async function POST(
       )
     }
 
+    const auditEvent = removed
+      ? await recordGroupAuditEvent({
+          supabase,
+          groupId: roomId,
+          eventType: "member_removed",
+          actorUserId: user.id,
+          targetUserId: target_user_id,
+          metadata: {
+            removal_reason: "membership_vote_threshold",
+          },
+        })
+      : null
+
     return NextResponse.json({
       vote_recorded: true,
       removed: Boolean(removed),
       message: removed ? "User has been removed from the room" : "Vote recorded",
+      audit: auditEvent ?? undefined,
     }, { status: 201 })
   } catch (error) {
     console.error("[vote-remove] error:", error)

--- a/app/api/rooms/join/route.ts
+++ b/app/api/rooms/join/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 import { validateInviteCode, incrementInviteUseCount } from "@/lib/groups/invite"
+import { recordGroupAuditEvent } from "@/lib/blockchain/audit"
 
 export async function POST(request: NextRequest) {
   try {
@@ -58,7 +59,19 @@ export async function POST(request: NextRequest) {
       console.info(`[rooms/join] User ${user.id} joined room ${roomId} via invite code ${validatedCode}`)
     }
 
-    return NextResponse.json({ success: true, membership: membership?.[0] })
+    const auditEvent = await recordGroupAuditEvent({
+      supabase,
+      groupId: roomId as string,
+      eventType: "member_joined",
+      actorUserId: user.id,
+      targetUserId: user.id,
+      metadata: {
+        invite_code_used: validatedCode ?? null,
+        membership_id: membership?.[0]?.id ?? null,
+      },
+    })
+
+    return NextResponse.json({ success: true, membership: membership?.[0], audit: auditEvent ?? undefined })
   } catch (error) {
     console.error("POST /api/rooms/join error:", error)
     return NextResponse.json({ error: "Failed to join room" }, { status: 500 })

--- a/app/api/rooms/join/route.ts
+++ b/app/api/rooms/join/route.ts
@@ -1,61 +1,84 @@
-import { createClient } from "@/lib/supabase/server"
-import { type NextRequest, NextResponse } from "next/server"
-import { validateInviteCode, incrementInviteUseCount } from "@/lib/groups/invite"
-import { recordGroupAuditEvent } from "@/lib/blockchain/audit"
+import { createClient } from "@/lib/supabase/server";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  validateInviteCode,
+  incrementInviteUseCount,
+} from "@/lib/groups/invite";
+import { recordGroupAuditEvent } from "@/lib/blockchain/audit";
+import { insertRoomActivity } from "@/lib/activity/room-activity";
+import { type SupabaseClient } from "@supabase/supabase-js";
 
 export async function POST(request: NextRequest) {
   try {
-    const supabase = await createClient()
+    const supabase = await createClient();
 
     const {
       data: { user },
-    } = await supabase.auth.getUser()
-    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    } = await supabase.auth.getUser();
+    if (!user)
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-    const body = await request.json()
-    const { inviteCode, groupId } = body as { inviteCode?: string; groupId?: string }
+    const body = await request.json();
+    const { inviteCode, groupId } = body as {
+      inviteCode?: string;
+      groupId?: string;
+    };
 
     if (!inviteCode && !groupId) {
-      return NextResponse.json({ error: "inviteCode or groupId is required" }, { status: 400 })
+      return NextResponse.json(
+        { error: "inviteCode or groupId is required" },
+        { status: 400 },
+      );
     }
 
-    let roomId: string | undefined = groupId
-    let validatedCode: string | undefined
+    let roomId: string | undefined = groupId;
+    let validatedCode: string | undefined;
 
     if (inviteCode) {
-      const validation = await validateInviteCode(supabase, inviteCode)
+      const validation = await validateInviteCode(supabase, inviteCode);
 
       if (!validation.valid) {
         console.warn(
-          `[rooms/join] Invalid invite attempt — user: ${user.id}, code: ${inviteCode}, reason: ${validation.error}`
-        )
-        return NextResponse.json({ error: validation.error }, { status: validation.status })
+          `[rooms/join] Invalid invite attempt — user: ${user.id}, code: ${inviteCode}, reason: ${validation.error}`,
+        );
+        return NextResponse.json(
+          { error: validation.error },
+          { status: validation.status },
+        );
       }
 
-      roomId = validation.roomId
-      validatedCode = validation.inviteCode
+      roomId = validation.roomId;
+      validatedCode = validation.inviteCode;
     }
 
     if (!roomId) {
-      return NextResponse.json({ error: "Room not found" }, { status: 404 })
+      return NextResponse.json({ error: "Room not found" }, { status: 404 });
     }
 
     // verify room exists
-    const { data: room } = await supabase.from("rooms").select("id").eq("id", roomId).maybeSingle()
-    if (!room) return NextResponse.json({ error: "Room not found" }, { status: 404 })
+    const { data: room } = await supabase
+      .from("rooms")
+      .select("id")
+      .eq("id", roomId)
+      .maybeSingle();
+    if (!room)
+      return NextResponse.json({ error: "Room not found" }, { status: 404 });
 
     // insert membership
     const { data: membership, error: membershipError } = await supabase
       .from("room_members")
       .insert({ user_id: user.id, room_id: roomId })
-      .select()
+      .select();
 
     if (membershipError) {
       // unique violation -> already a member
       if (membershipError.code === "23505") {
-        return NextResponse.json({ message: "Already a member", success: true })
+        return NextResponse.json({
+          message: "Already a member",
+          success: true,
+        });
       }
-      throw membershipError
+      throw membershipError;
     }
 
     // Best-effort: log the join event (separate from chat messages)
@@ -65,14 +88,16 @@ export async function POST(request: NextRequest) {
         event_type: "user_joined",
         actor_user_id: user.id,
         metadata: { via: validatedCode ? "invite" : "direct" },
-      })
+      });
     } catch (e) {
-      console.warn("[activity] failed to insert user_joined log", e)
+      console.warn("[activity] failed to insert user_joined log", e);
     }
 
     if (validatedCode) {
-      await incrementInviteUseCount(supabase, validatedCode)
-      console.info(`[rooms/join] User ${user.id} joined room ${roomId} via invite code ${validatedCode}`)
+      await incrementInviteUseCount(supabase, validatedCode);
+      console.info(
+        `[rooms/join] User ${user.id} joined room ${roomId} via invite code ${validatedCode}`,
+      );
     }
 
     const auditEvent = await recordGroupAuditEvent({
@@ -85,11 +110,15 @@ export async function POST(request: NextRequest) {
         invite_code_used: validatedCode ?? null,
         membership_id: membership?.[0]?.id ?? null,
       },
-    })
+    });
 
-    return NextResponse.json({ success: true, membership: membership?.[0], audit: auditEvent ?? undefined })
+    return NextResponse.json({
+      success: true,
+      membership: membership?.[0],
+      audit: auditEvent ?? undefined,
+    });
   } catch (error) {
-    console.error("POST /api/rooms/join error:", error)
-    return NextResponse.json({ error: "Failed to join room" }, { status: 500 })
+    console.error("POST /api/rooms/join error:", error);
+    return NextResponse.json({ error: "Failed to join room" }, { status: 500 });
   }
 }

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -10,6 +10,7 @@ import {
   logBlockchainOperation,
   generateCorrelationId,
 } from "@/lib/blockchain/logger";
+import { recordGroupAuditEvent } from "@/lib/blockchain/audit";
 
 export async function GET(request: NextRequest) {
   try {
@@ -141,6 +142,7 @@ export async function POST(request: NextRequest) {
     let explorerUrl: string | null = null;
     let actualFeeCharged: string | null = null;
     let memoGroupId: string | null = null;
+    let auditEvent = null;
 
     try {
       const result = await submitMetadataHash(room.id, metadataHash, max_fee);
@@ -231,6 +233,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    auditEvent = await recordGroupAuditEvent({
+      supabase,
+      groupId: room.id,
+      eventType: "group_created",
+      actorUserId: user.id,
+      targetUserId: user.id,
+      maxFee: max_fee,
+      metadata: {
+        room_name: room.name,
+        is_private: room.is_private,
+        metadata_hash: metadataHash,
+        group_creation_transaction_hash: stellarTxHash,
+      },
+    });
+
     // Return success response with blockchain info
     return NextResponse.json(
       {
@@ -248,6 +265,7 @@ export async function POST(request: NextRequest) {
           explorerUrl: explorerUrl || undefined,
           memoGroupId: memoGroupId || undefined,
         },
+        audit: auditEvent || undefined,
       },
       { status: 201 },
     );

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -11,11 +11,14 @@ import {
   generateCorrelationId,
 } from "@/lib/blockchain/logger";
 import { recordGroupAuditEvent } from "@/lib/blockchain/audit";
+import { insertRoomActivity } from "@/lib/activity/room-activity";
+import { type SupabaseClient } from "@supabase/supabase-js";
 
 export async function GET(request: NextRequest) {
   try {
     // Check if Supabase is configured (not dummy)
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "https://dummy.supabase.co";
+    const supabaseUrl =
+      process.env.NEXT_PUBLIC_SUPABASE_URL || "https://dummy.supabase.co";
     if (supabaseUrl.includes("dummy")) {
       // Return empty rooms for demo mode without Supabase
       return NextResponse.json({ rooms: [] });
@@ -69,11 +72,15 @@ export async function POST(request: NextRequest) {
 
   try {
     // Check if Supabase is configured (not dummy)
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "https://dummy.supabase.co";
+    const supabaseUrl =
+      process.env.NEXT_PUBLIC_SUPABASE_URL || "https://dummy.supabase.co";
     if (supabaseUrl.includes("dummy")) {
       // Return error in demo mode without Supabase
       return NextResponse.json(
-        { error: "Room creation not available in demo mode. Please configure Supabase." },
+        {
+          error:
+            "Room creation not available in demo mode. Please configure Supabase.",
+        },
         { status: 503 },
       );
     }
@@ -94,7 +101,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "name is required" }, { status: 400 });
     }
 
-    const roomId = `room_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    const roomId = `room_${Date.now()}_${Math.random()
+      .toString(36)
+      .substr(2, 9)}`;
     const createdAt = new Date().toISOString();
 
     // Insert group into database first

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -10,6 +10,7 @@ import React, {
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { ChatEmptyState } from "@/components/chat-empty-state";
+import { GroupAuditDialog } from "@/components/group-audit-dialog";
 import {
   PresenceIndicator,
   type PresenceStatus,
@@ -28,6 +29,7 @@ import {
   Search,
   SendHorizontal,
   Smile,
+  ScrollText,
   Users,
 } from "lucide-react";
 
@@ -70,6 +72,7 @@ export default function ChatPage() {
   const [selectedChatId, setSelectedChatId] = useState<string | null>(null);
   const [inputMessage, setInputMessage] = useState("");
   const [roomMembersOpen, setRoomMembersOpen] = useState(false);
+  const [auditTrailOpen, setAuditTrailOpen] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [activeMobileTab, setActiveMobileTab] = useState<
     "chats" | "conversation"
@@ -585,14 +588,24 @@ export default function ChatPage() {
                         </div>
                       </div>
 
-                      <button
-                        type="button"
-                        onClick={() => setRoomMembersOpen(true)}
-                        className="inline-flex items-center gap-1.5 rounded-lg border border-border/80 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40"
-                      >
-                        <Users className="h-3.5 w-3.5" />
-                        Members
-                      </button>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setAuditTrailOpen(true)}
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-border/80 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40"
+                        >
+                          <ScrollText className="h-3.5 w-3.5" />
+                          Audit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setRoomMembersOpen(true)}
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-border/80 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40"
+                        >
+                          <Users className="h-3.5 w-3.5" />
+                          Members
+                        </button>
+                      </div>
                     </div>
                   </header>
 
@@ -712,6 +725,11 @@ export default function ChatPage() {
                     roomId={selectedChat.id}
                     open={roomMembersOpen}
                     onOpenChange={setRoomMembersOpen}
+                  />
+                  <GroupAuditDialog
+                    groupId={selectedChat.id}
+                    open={auditTrailOpen}
+                    onOpenChange={setAuditTrailOpen}
                   />
                 </>
               )}

--- a/components/group-audit-dialog.tsx
+++ b/components/group-audit-dialog.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import * as Dialog from "@radix-ui/react-dialog"
+import { ExternalLink, Loader2, ScrollText } from "lucide-react"
+import toast from "react-hot-toast"
+import { cn } from "@/lib/utils"
+
+type AuditEvent = {
+  eventId: string
+  eventType: string
+  actorUserId: string | null
+  targetUserId: string | null
+  transactionHash: string | null
+  explorerUrl: string | null
+  status: "pending" | "submitted" | "failed"
+  error: string | null
+  timestamp: string
+}
+
+type GroupAuditDialogProps = {
+  groupId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const EVENT_LABELS: Record<string, string> = {
+  group_created: "Group created",
+  member_joined: "Member joined",
+  member_left: "Member left",
+  member_removed: "Member removed",
+}
+
+function displayId(id: string | null) {
+  if (!id) return "System"
+  return id.length > 12 ? `${id.slice(0, 6)}...${id.slice(-4)}` : id
+}
+
+export function GroupAuditDialog({
+  groupId,
+  open,
+  onOpenChange,
+}: GroupAuditDialogProps) {
+  const [events, setEvents] = useState<AuditEvent[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open || !groupId) return
+
+    const fetchAuditTrail = async () => {
+      setLoading(true)
+      try {
+        const response = await fetch(
+          `/api/groups/${encodeURIComponent(groupId)}/audit?limit=25`
+        )
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) {
+          throw new Error(data.error ?? "Failed to load audit trail")
+        }
+
+        setEvents(data.auditTrail ?? [])
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to load audit trail")
+        setEvents([])
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void fetchAuditTrail()
+  }, [open, groupId])
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-[calc(100%-1.5rem)] max-w-2xl -translate-x-1/2 -translate-y-1/2",
+            "rounded-2xl border border-border/60 bg-[#0f0f16] p-5 shadow-xl",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          )}
+        >
+          <div className="flex items-center gap-2 border-b border-border/60 pb-3 mb-3">
+            <ScrollText className="h-5 w-5 text-primary" />
+            <Dialog.Title className="text-sm font-semibold">
+              Audit trail
+            </Dialog.Title>
+          </div>
+
+          {loading ? (
+            <div className="flex items-center justify-center py-10 text-muted-foreground">
+              <Loader2 className="h-6 w-6 animate-spin" />
+            </div>
+          ) : events.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-6">
+              No audit events have been recorded for this group yet.
+            </p>
+          ) : (
+            <ul className="max-h-[60vh] space-y-2 overflow-y-auto">
+              {events.map((event) => (
+                <li
+                  key={event.eventId}
+                  className="rounded-xl border border-border/60 bg-[#181822] px-3 py-3"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium">
+                        {EVENT_LABELS[event.eventType] ?? event.eventType}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {new Date(event.timestamp).toLocaleString()}
+                      </p>
+                    </div>
+                    <span
+                      className={cn(
+                        "rounded-full px-2 py-1 text-[11px] font-medium",
+                        event.status === "submitted" && "bg-emerald-500/15 text-emerald-300",
+                        event.status === "pending" && "bg-yellow-500/15 text-yellow-300",
+                        event.status === "failed" && "bg-destructive/20 text-destructive"
+                      )}
+                    >
+                      {event.status}
+                    </span>
+                  </div>
+
+                  <div className="mt-2 grid gap-1 text-xs text-muted-foreground sm:grid-cols-2">
+                    <span>Actor: {displayId(event.actorUserId)}</span>
+                    <span>Target: {displayId(event.targetUserId)}</span>
+                  </div>
+
+                  {event.transactionHash && event.explorerUrl && (
+                    <a
+                      href={event.explorerUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-2 inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+                    >
+                      {displayId(event.transactionHash)}
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  )}
+
+                  {event.error && (
+                    <p className="mt-2 text-xs text-destructive">
+                      {event.error}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="mt-4 flex justify-end">
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                className="rounded-lg border border-border/60 bg-[#181822] px-3 py-1.5 text-xs font-medium hover:bg-[#232330] transition"
+              >
+                Close
+              </button>
+            </Dialog.Close>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/lib/blockchain/audit.ts
+++ b/lib/blockchain/audit.ts
@@ -1,0 +1,178 @@
+import { createHash, randomUUID } from "crypto";
+import type { AuditEventType } from "@/types/blockchain";
+import { submitAuditEvent } from "@/lib/blockchain/stellar-service";
+import { getExplorerUrl, loadStellarConfig } from "@/lib/blockchain/stellar-config";
+import { logBlockchainOperation, generateCorrelationId } from "@/lib/blockchain/logger";
+
+type SupabaseErrorLike = { message: string };
+type SupabaseMutationResult = PromiseLike<{ error: SupabaseErrorLike | null }>;
+type SupabaseUpdateBuilder = {
+  eq: (column: string, value: string) => SupabaseMutationResult;
+};
+type SupabaseTableLike = {
+  insert: (values: Record<string, unknown>) => SupabaseMutationResult;
+  update: (values: Record<string, unknown>) => SupabaseUpdateBuilder;
+};
+type SupabaseClientLike = {
+  from: (table: string) => SupabaseTableLike;
+};
+
+type AuditStatus = "pending" | "submitted" | "failed";
+
+export type RecordAuditEventInput = {
+  supabase: SupabaseClientLike;
+  groupId: string;
+  eventType: AuditEventType;
+  actorUserId?: string | null;
+  targetUserId?: string | null;
+  metadata?: Record<string, unknown>;
+  maxFee?: string | number;
+};
+
+export type RecordedAuditEvent = {
+  eventId: string;
+  eventType: AuditEventType;
+  transactionHash: string | null;
+  status: AuditStatus;
+  explorerUrl: string | null;
+  error: string | null;
+};
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = canonicalize((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+}
+
+function computeAuditMetadataHash(metadata: Record<string, unknown>): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(metadata)))
+    .digest("hex");
+}
+
+function getAuditExplorerUrl(transactionHash: string | null): string | null {
+  if (!transactionHash) return null;
+
+  const config = loadStellarConfig();
+  if (!config) return null;
+
+  return getExplorerUrl(transactionHash, config.network);
+}
+
+export async function recordGroupAuditEvent({
+  supabase,
+  groupId,
+  eventType,
+  actorUserId,
+  targetUserId,
+  metadata = {},
+  maxFee,
+}: RecordAuditEventInput): Promise<RecordedAuditEvent | null> {
+  const correlationId = generateCorrelationId();
+  const eventId = randomUUID();
+  const occurredAt = new Date().toISOString();
+  const eventMetadata = {
+    ...metadata,
+    group_id: groupId,
+    event_id: eventId,
+    event_type: eventType,
+    actor_user_id: actorUserId ?? null,
+    target_user_id: targetUserId ?? null,
+    occurred_at: occurredAt,
+  };
+  const metadataHash = computeAuditMetadataHash(eventMetadata);
+
+  const { error: insertError } = await supabase
+    .from("group_audit_events")
+    .insert({
+      event_id: eventId,
+      group_id: groupId,
+      event_type: eventType,
+      actor_user_id: actorUserId ?? null,
+      target_user_id: targetUserId ?? null,
+      status: "pending",
+      metadata: eventMetadata,
+      metadata_hash: metadataHash,
+      created_at: occurredAt,
+    });
+
+  if (insertError) {
+    logBlockchainOperation("error", "Failed to persist audit event before submission", {
+      groupId,
+      eventId,
+      eventType,
+      error: {
+        type: "DatabaseError",
+        message: insertError.message,
+      },
+    }, correlationId);
+    return null;
+  }
+
+  const result = await submitAuditEvent(groupId, eventId, eventType, metadataHash, maxFee);
+
+  if (result.success && result.transactionHash) {
+    const { error: updateError } = await supabase
+      .from("group_audit_events")
+      .update({
+        status: "submitted",
+        transaction_hash: result.transactionHash,
+        stellar_memo: result.auditMemo ?? null,
+        submitted_at: new Date().toISOString(),
+        error_message: null,
+      })
+      .eq("event_id", eventId);
+
+    if (updateError) {
+      logBlockchainOperation("warn", "Audit transaction submitted but database update failed", {
+        groupId,
+        eventId,
+        eventType,
+        transactionHash: result.transactionHash,
+        error: {
+          type: "DatabaseError",
+          message: updateError.message,
+        },
+      }, correlationId);
+    }
+
+    return {
+      eventId,
+      eventType,
+      transactionHash: result.transactionHash,
+      status: "submitted",
+      explorerUrl: getAuditExplorerUrl(result.transactionHash),
+      error: null,
+    };
+  }
+
+  const errorMessage = result.error ?? "Audit transaction failed";
+  await supabase
+    .from("group_audit_events")
+    .update({
+      status: "failed",
+      stellar_memo: result.auditMemo ?? null,
+      error_message: errorMessage,
+    })
+    .eq("event_id", eventId);
+
+  return {
+    eventId,
+    eventType,
+    transactionHash: null,
+    status: "failed",
+    explorerUrl: null,
+    error: errorMessage,
+  };
+}

--- a/lib/blockchain/stellar-service.ts
+++ b/lib/blockchain/stellar-service.ts
@@ -4,6 +4,18 @@ import { loadStellarConfig, isConfigured, getExplorerUrl } from "./stellar-confi
 import { logBlockchainOperation, generateCorrelationId } from "./logger";
 import { deriveMemoGroupId, validateMemoGroupId, STELLAR_MEMO_MAX_BYTES } from "./memo";
 
+const AUDIT_EVENT_CODES = {
+  group_created: "c",
+  member_joined: "j",
+  member_left: "l",
+  member_removed: "r",
+} as const;
+
+function buildAuditMemo(eventId: string, eventType: keyof typeof AUDIT_EVENT_CODES): string {
+  const compactId = eventId.replace(/-/g, "").slice(0, 21);
+  return `aca_${AUDIT_EVENT_CODES[eventType]}_${compactId}`;
+}
+
 /**
  * Submits a metadata hash to the Stellar blockchain.
  *
@@ -160,6 +172,140 @@ export async function submitMetadataHash(
 
     return {
       success: false,
+      error: error.message || "Transaction failed",
+    };
+  }
+}
+
+/**
+ * Submits an immutable audit marker to Stellar.
+ *
+ * Stellar TEXT memos are limited to 28 bytes, so the memo stores a compact
+ * audit-event reference: "aca_<event-code>_<event-id-prefix>". The complete
+ * event payload, metadata hash, transaction hash, and memo are stored in
+ * Supabase for fast lookup and verification.
+ */
+export async function submitAuditEvent(
+  groupId: string,
+  eventId: string,
+  eventType: keyof typeof AUDIT_EVENT_CODES,
+  metadataHash: string,
+  maxFee?: string | number
+): Promise<StellarTransactionResult> {
+  const correlationId = generateCorrelationId();
+  const startTime = Date.now();
+
+  if (!isConfigured()) {
+    logBlockchainOperation("warn", "Skipping audit transaction - configuration missing", {
+      groupId,
+      eventId,
+      eventType,
+      metadataHash,
+      configured: false,
+    }, correlationId);
+
+    return {
+      success: false,
+      error: "Stellar configuration not available",
+    };
+  }
+
+  const config = loadStellarConfig();
+  if (!config) {
+    return {
+      success: false,
+      error: "Failed to load Stellar configuration",
+    };
+  }
+
+  const auditMemo = buildAuditMemo(eventId, eventType);
+  if (Buffer.byteLength(auditMemo, "utf8") > STELLAR_MEMO_MAX_BYTES) {
+    return {
+      success: false,
+      error: "Audit memo exceeds Stellar memo limit",
+    };
+  }
+
+  try {
+    const server = new StellarSdk.Horizon.Server(config.horizonUrl);
+    const sourceKeypair = StellarSdk.Keypair.fromSecret(config.sourceSecret);
+    const sourcePublicKey = sourceKeypair.publicKey();
+
+    const account = await Promise.race([
+      server.loadAccount(sourcePublicKey),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Timeout loading account")), config.transactionTimeout)
+      ),
+    ]);
+
+    const feeToUse = maxFee ? maxFee.toString() : StellarSdk.BASE_FEE;
+    const transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: feeToUse,
+      networkPassphrase: config.network === "testnet"
+        ? StellarSdk.Networks.TESTNET
+        : StellarSdk.Networks.PUBLIC,
+    })
+      .addOperation(
+        StellarSdk.Operation.payment({
+          destination: sourcePublicKey,
+          asset: StellarSdk.Asset.native(),
+          amount: "0.0000001",
+        })
+      )
+      .addMemo(StellarSdk.Memo.text(auditMemo))
+      .setTimeout(30)
+      .build();
+
+    transaction.sign(sourceKeypair);
+
+    const result = await Promise.race([
+      server.submitTransaction(transaction),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("Transaction submission timeout")), config.transactionTimeout)
+      ),
+    ]);
+
+    const duration = Date.now() - startTime;
+    const feeCharged = (result as any).fee_charged ? (result as any).fee_charged.toString() : feeToUse.toString();
+
+    logBlockchainOperation("info", "Audit transaction successful", {
+      groupId,
+      eventId,
+      eventType,
+      metadataHash,
+      auditMemo,
+      transactionHash: result.hash,
+      feeCharged,
+      duration,
+      ledger: result.ledger,
+    }, correlationId);
+
+    return {
+      success: true,
+      transactionHash: result.hash,
+      feeCharged,
+      auditMemo,
+    };
+  } catch (error: any) {
+    const duration = Date.now() - startTime;
+
+    logBlockchainOperation("error", "Audit transaction failed", {
+      groupId,
+      eventId,
+      eventType,
+      metadataHash,
+      auditMemo,
+      duration,
+      error: {
+        type: error.name || "UnknownError",
+        message: error.message || "Unknown error occurred",
+        stack: error.stack,
+      },
+    }, correlationId);
+
+    return {
+      success: false,
+      auditMemo,
       error: error.message || "Transaction failed",
     };
   }

--- a/scripts/012_group_audit_events.sql
+++ b/scripts/012_group_audit_events.sql
@@ -1,0 +1,78 @@
+-- Migration: Add group audit event mapping for on-chain audit trail
+-- Description: Stores eventId/eventType/transactionHash mappings and related metadata.
+
+create table if not exists public.group_audit_events (
+  event_id uuid primary key default gen_random_uuid(),
+  group_id text not null references public.rooms(id) on delete cascade,
+  event_type text not null check (
+    event_type in ('group_created', 'member_joined', 'member_left', 'member_removed')
+  ),
+  actor_user_id uuid references auth.users(id) on delete set null,
+  target_user_id uuid references auth.users(id) on delete set null,
+  transaction_hash text,
+  stellar_memo text,
+  metadata_hash text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  status text not null default 'pending' check (status in ('pending', 'submitted', 'failed')),
+  error_message text,
+  created_at timestamptz not null default timezone('utc'::text, now()),
+  submitted_at timestamptz
+);
+
+create index if not exists group_audit_events_group_created_idx
+  on public.group_audit_events(group_id, created_at desc);
+
+create index if not exists group_audit_events_type_idx
+  on public.group_audit_events(event_type);
+
+create index if not exists group_audit_events_tx_hash_idx
+  on public.group_audit_events(transaction_hash)
+  where transaction_hash is not null;
+
+create unique index if not exists group_audit_events_stellar_memo_idx
+  on public.group_audit_events(stellar_memo)
+  where stellar_memo is not null;
+
+alter table public.group_audit_events enable row level security;
+
+drop policy if exists "Users can leave rooms" on public.room_members;
+create policy "Users can leave rooms"
+  on public.room_members for delete
+  using (auth.uid() = user_id);
+
+create policy "Authenticated users can view group audit events"
+  on public.group_audit_events for select
+  using (
+    auth.uid() is not null
+    and (
+      exists (
+        select 1 from public.rooms r
+        where r.id = group_audit_events.group_id
+          and (r.is_private = false or r.created_by = auth.uid())
+      )
+      or exists (
+        select 1 from public.room_members rm
+        where rm.room_id = group_audit_events.group_id
+          and rm.user_id = auth.uid()
+          and rm.removed_at is null
+      )
+    )
+  );
+
+create policy "Authenticated actors can create audit events"
+  on public.group_audit_events for insert
+  with check (auth.uid() = actor_user_id);
+
+create policy "Authenticated actors can update their audit events"
+  on public.group_audit_events for update
+  using (auth.uid() = actor_user_id)
+  with check (auth.uid() = actor_user_id);
+
+comment on table public.group_audit_events is
+  'On-chain audit trail mapping group events to Stellar transaction hashes';
+comment on column public.group_audit_events.event_id is
+  'Stable audit event identifier referenced by the Stellar memo';
+comment on column public.group_audit_events.transaction_hash is
+  'Stellar transaction hash for the on-chain audit marker';
+comment on column public.group_audit_events.stellar_memo is
+  'Compact Stellar memo containing event type and event ID prefix';

--- a/scripts/MIGRATIONS_README.md
+++ b/scripts/MIGRATIONS_README.md
@@ -12,6 +12,7 @@ Included migrations (apply in numeric order):
 - `006_unread_view.sql`          (new)
 - `007_create_group_membership.sql`  (new)
 - `011_enhance_invites_for_group_join.sql` (new)
+- `012_group_audit_events.sql` (new)
 
 ## How to apply (psql)
 
@@ -30,6 +31,7 @@ psql "$DATABASE_URL" -f scripts/005_add_last_read_to_room_members.sql
 psql "$DATABASE_URL" -f scripts/006_unread_view.sql
 psql "$DATABASE_URL" -f scripts/007_create_group_membership.sql
 psql "$DATABASE_URL" -f scripts/011_enhance_invites_for_group_join.sql
+psql "$DATABASE_URL" -f scripts/012_group_audit_events.sql
 ```
 
 ## How to apply (Supabase)
@@ -43,6 +45,7 @@ If the project uses Supabase, maintainers can run the same `psql` commands again
 - `scripts/006_unread_view.sql` creates `public.user_room_unreads` view and grants `SELECT` to `public` for convenience; adjust privileges as needed.
 - `scripts/007_create_group_membership.sql` creates `public.group_membership` table for wallet-based group membership tracking.
 - `scripts/011_enhance_invites_for_group_join.sql` adds `max_uses` and `use_count` columns to `public.invites`, adds RLS policies for authenticated read/update, and creates the `increment_invite_use_count` SQL function for atomic usage tracking.
+- `scripts/012_group_audit_events.sql` creates `public.group_audit_events`, which maps group audit events to Stellar transaction hashes and exposes the audit trail to authenticated users who can access the group.
 - A development-only endpoint (`/api/rooms/seed-test`) was added that seeds a room for an authenticated user. It requires a valid Supabase session; do not enable any service-role or unauthenticated behavior in production without review.
 
 ## Including migrations in PRs

--- a/types/blockchain.ts
+++ b/types/blockchain.ts
@@ -15,8 +15,16 @@ export interface StellarTransactionResult {
   feeCharged?: string;
   /** The group memo embedded in the Stellar transaction (≤28 bytes). */
   memoGroupId?: string;
+  /** The audit memo embedded in the Stellar transaction (≤28 bytes). */
+  auditMemo?: string;
   error?: string;
 }
+
+export type AuditEventType =
+  | "group_created"
+  | "member_joined"
+  | "member_left"
+  | "member_removed";
 
 export interface StellarTransaction {
   hash: string;


### PR DESCRIPTION
Close #135 

## Summary of the issue
Group creation and membership changes were not consistently recorded as immutable on-chain audit events. Existing Stellar integration anchored some group metadata, but there was no audit-event table, no event-to-transaction hash mapping, and no endpoint/UI for users or admins to inspect group history.

## Root cause
The codebase lacked a reusable audit logging layer. Membership flows wrote only to Supabase (`room_members`, removal votes), while group creation stored blockchain metadata directly on the room record. This left no normalized audit trail for group lifecycle events.

## Solution implemented
Implemented a Stellar-backed audit logging system for group events. Each audit event is persisted in Supabase, submitted to Stellar with a compact memo containing event metadata, then updated with the resulting transaction hash or failure state.

## Key changes made
- Added `group_audit_events` migration with RLS, indexes, event status, metadata hash, Stellar memo, and transaction hash fields.
- Added `recordGroupAuditEvent` helper for DB-first audit recording and Stellar submission.
- Added Stellar audit transaction submission using compact memos.
- Logged group creation, member joins, member leaves, and vote-triggered removals.
- Added `GET /api/groups/[id]/audit` with pagination and filtering.
- Added a chat Audit dialog to view event history and explorer links.
- Added voluntary leave support via `DELETE /api/rooms/[roomId]/members`.

## Trade-offs / considerations
- Group creation now creates a dedicated audit transaction in addition to the existing metadata anchoring transaction.
- If Stellar submission fails or config is missing, the audit event remains queryable with `failed` status and an error message.
- The Stellar memo is intentionally compact because Stellar text memos are limited to 28 bytes; full metadata remains in Supabase with a hash.

## Testing steps
1. Apply `scripts/012_group_audit_events.sql`.
2. Configure Stellar env vars.
3. Create a group and confirm an audit event appears with a transaction hash.
4. Join a group and confirm `member_joined` appears.
5. Leave via `DELETE /api/rooms/:roomId/members` and confirm `member_left`.
6. Trigger vote removal and confirm `member_removed`.
7. Open chat, click `Audit`, and verify the audit trail renders with explorer links.
8. Run `npm run lint`.