### PR TITLE
feat: secure logger and group list sidebar active state

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -448,33 +448,54 @@ export default function ChatPage() {
                           type="button"
                           onClick={() => handleSelectChat(chat.id)}
                           className={cn(
-                            "w-full text-left p-3 rounded-xl transition mb-1",
-                            "border border-transparent hover:bg-muted/40",
-                            isActive && "bg-primary/10 border-primary/25",
+                            "w-full text-left p-3 rounded-xl transition-all duration-150 mb-1",
+                            "border hover:bg-muted/40",
+                            isActive
+                              ? "bg-primary/10 border-primary/30 shadow-[inset_3px_0_0_hsl(var(--primary))]"
+                              : "border-transparent",
                           )}
                         >
-                          <div className="flex items-start justify-between gap-2">
-                            <div className="min-w-0">
-                              <div className="flex items-center gap-2">
-                                <PresenceIndicator status={chat.status} />
-                                <p className="font-medium text-sm truncate">
-                                  {chat.name}
-                                </p>
-                              </div>
-                              <p className="text-xs text-muted-foreground truncate mt-1">
-                                {chat.lastMessage}
-                              </p>
+                          <div className="flex items-start gap-2.5">
+                            <div
+                              className={cn(
+                                "shrink-0 h-9 w-9 rounded-full flex items-center justify-center text-sm font-semibold uppercase select-none",
+                                isActive
+                                  ? "bg-primary text-primary-foreground"
+                                  : "bg-muted text-muted-foreground",
+                              )}
+                            >
+                              {chat.name.charAt(0)}
                             </div>
 
-                            <div className="shrink-0 text-right">
-                              <p className="text-[11px] text-muted-foreground">
-                                {chat.lastSeen}
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center justify-between gap-1">
+                                <div className="flex items-center gap-1.5 min-w-0">
+                                  <PresenceIndicator status={chat.status} />
+                                  <p
+                                    className={cn(
+                                      "text-sm truncate",
+                                      isActive
+                                        ? "font-semibold text-foreground"
+                                        : "font-medium",
+                                    )}
+                                  >
+                                    {chat.name}
+                                  </p>
+                                </div>
+                                <div className="shrink-0 flex flex-col items-end gap-1">
+                                  <p className="text-[11px] text-muted-foreground whitespace-nowrap">
+                                    {chat.lastSeen}
+                                  </p>
+                                  {chat.unreadCount > 0 && (
+                                    <span className="inline-flex items-center justify-center min-w-5 h-5 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold px-1.5">
+                                      {chat.unreadCount}
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                              <p className="text-xs text-muted-foreground truncate mt-0.5">
+                                {chat.lastMessage}
                               </p>
-                              {chat.unreadCount > 0 && (
-                                <span className="inline-flex items-center justify-center min-w-5 h-5 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold mt-1 px-1.5">
-                                  {chat.unreadCount}
-                                </span>
-                              )}
                             </div>
                           </div>
                         </button>

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,129 @@
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LOG_LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const ACTIVE_LEVEL: LogLevel =
+  (process.env.LOG_LEVEL as LogLevel | undefined) ?? "info";
+
+const SENSITIVE_KEYS = new Set([
+  "ip",
+  "ipaddress",
+  "ip_address",
+  "x-forwarded-for",
+  "x-real-ip",
+  "content",
+  "message",
+  "text",
+  "body",
+  "payload",
+  "metadata",
+  "headers",
+  "cookies",
+  "password",
+  "token",
+  "secret",
+  "apikey",
+  "api_key",
+  "authorization",
+  "email",
+  "phone",
+  "address",
+  "location",
+]);
+
+function sanitize(value: unknown, depth = 0): unknown {
+  if (depth > 8) return "[MaxDepth]";
+  if (value === null || value === undefined) return value;
+  if (typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((v) => sanitize(v, depth + 1));
+
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    result[key] = SENSITIVE_KEYS.has(key.toLowerCase())
+      ? "[REDACTED]"
+      : sanitize(val, depth + 1);
+  }
+  return result;
+}
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  event: string;
+  correlationId?: string;
+  context?: Record<string, unknown>;
+}
+
+function shouldLog(level: LogLevel): boolean {
+  return LOG_LEVEL_RANK[level] >= LOG_LEVEL_RANK[ACTIVE_LEVEL];
+}
+
+function emit(
+  level: LogLevel,
+  event: string,
+  context?: Record<string, unknown>,
+  correlationId?: string,
+): void {
+  if (!shouldLog(level)) return;
+
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    ...(correlationId !== undefined && { correlationId }),
+    ...(context !== undefined && {
+      context: sanitize(context) as Record<string, unknown>,
+    }),
+  };
+
+  const line = JSON.stringify(entry);
+
+  switch (level) {
+    case "debug":
+    case "info":
+      console.log(`[${level.toUpperCase()}]`, line);
+      break;
+    case "warn":
+      console.warn(`[WARN]`, line);
+      break;
+    case "error":
+      console.error(`[ERROR]`, line);
+      break;
+  }
+}
+
+export const logger = {
+  debug(
+    event: string,
+    context?: Record<string, unknown>,
+    correlationId?: string,
+  ) {
+    emit("debug", event, context, correlationId);
+  },
+  info(
+    event: string,
+    context?: Record<string, unknown>,
+    correlationId?: string,
+  ) {
+    emit("info", event, context, correlationId);
+  },
+  warn(
+    event: string,
+    context?: Record<string, unknown>,
+    correlationId?: string,
+  ) {
+    emit("warn", event, context, correlationId);
+  },
+  error(
+    event: string,
+    context?: Record<string, unknown>,
+    correlationId?: string,
+  ) {
+    emit("error", event, context, correlationId);
+  },
+};


### PR DESCRIPTION
## Summary

- Implements a centralized, privacy-safe logging service (`lib/logger.ts`) with automatic redaction of sensitive fields
- Enhances the group list sidebar with a visually distinct active-group state, group avatars, and improved last-message layout

## Changes

### `lib/logger.ts` — new file
- Configurable log level via `LOG_LEVEL` env var (`debug` | `info` | `warn` | `error`; defaults to `info`)
- Structured JSON log entries: `{ timestamp, level, event, correlationId?, context? }`
- Deep sanitizer that redacts any field whose key matches a sensitive set — `ip`, `content`, `message`, `token`, `email`, `metadata`, `password`, `authorization`, etc. — at any nesting depth, so no PII or message content ever reaches the log output
- Four-method surface: `logger.debug / .info / .warn / .error`

### `app/chat/page.tsx` — sidebar enhancement
- Each group row now shows a circular avatar with the group's first letter (filled with primary colour when active, muted otherwise)
- Active group gets an inset left-border accent (`shadow-[inset_3px_0_0_hsl(var(--primary))]`) + bolder name, making the selected room unmistakably distinct
- Last-message preview and timestamp/unread badge rearranged for a cleaner two-row layout

## Closes

Closes #94
Closes #105

## Test plan

- [ ] Visit `/chat` — verify groups sidebar renders with avatars and last-message previews
- [ ] Click a group — confirm the active-state highlight (left accent + avatar fill + bold name) appears and switches correctly
- [ ] Import `logger` in any server file and call `logger.info("test", { ip: "1.2.3.4", content: "hello" })` — confirm both fields are `[REDACTED]` in output
- [ ] Set `LOG_LEVEL=warn` and confirm `logger.info(...)` calls produce no output
- [ ] Set `LOG_LEVEL=debug` and confirm all levels emit

🤖 Generated with [Claude Code](https://claude.com/claude-code)