### PR TITLE
feat: add chat message search with keyword highlighting

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -17,7 +17,9 @@ import {
 import { RoomMembersDialog } from "@/components/room-members-dialog";
 import ConnectWallet from "@/components/wallet-connector";
 import { RoomActivityPanel } from "@/components/room-activity-panel";
+import { MessageSearchBar } from "@/components/message-search-bar";
 import { cn } from "@/lib/utils";
+import { highlightText } from "@/lib/highlight-text";
 import { handleAppError } from "@/lib/error-handler"; // Integrated Error Handler
 import {
   ArrowLeft,
@@ -79,6 +81,10 @@ export default function ChatPage() {
   const [currentUser, setCurrentUser] = useState<{ id: string } | null>(null);
   const [isLoadingRooms, setIsLoadingRooms] = useState(true);
   const [isSending, setIsSending] = useState(false);
+
+  // Message search state
+  const [messageSearchOpen, setMessageSearchOpen] = useState(false);
+  const [messageSearchQuery, setMessageSearchQuery] = useState("");
 
   const [chats, setChats] = useState<ChatPreview[]>([]);
   const [messagesByChat, setMessagesByChat] = useState<
@@ -444,6 +450,26 @@ export default function ChatPage() {
 
   const messages = selectedChat ? messagesByChat[selectedChat.id] || [] : [];
 
+  // Filter messages by search query (client-side, over loaded messages)
+  const filteredMessages = useMemo(() => {
+    if (!messageSearchQuery.trim()) return messages;
+    const lowered = messageSearchQuery.toLowerCase();
+    return messages.filter((msg) =>
+      msg.text.toLowerCase().includes(lowered),
+    );
+  }, [messages, messageSearchQuery]);
+
+  const handleCloseSearch = useCallback(() => {
+    setMessageSearchOpen(false);
+    setMessageSearchQuery("");
+  }, []);
+
+  // Reset search when switching rooms
+  useEffect(() => {
+    setMessageSearchQuery("");
+    setMessageSearchOpen(false);
+  }, [selectedChatId]);
+
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Header />
@@ -586,16 +612,41 @@ export default function ChatPage() {
                         </div>
                       </div>
 
-                      <button
-                        type="button"
-                        onClick={() => setRoomMembersOpen(true)}
-                        className="inline-flex items-center gap-1.5 rounded-lg border border-border/80 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40"
-                      >
-                        <Users className="h-3.5 w-3.5" />
-                        Members
-                      </button>
+                      <div className="flex items-center gap-1.5 shrink-0">
+                        {/* Search messages toggle */}
+                        <button
+                          type="button"
+                          aria-label="Search messages"
+                          aria-pressed={messageSearchOpen}
+                          onClick={() => setMessageSearchOpen((prev) => !prev)}
+                          className={cn(
+                            "inline-flex items-center justify-center h-8 w-8 rounded-lg border border-border/80 text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors",
+                            messageSearchOpen && "bg-primary/10 border-primary/30 text-primary",
+                          )}
+                        >
+                          <Search className="h-3.5 w-3.5" />
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={() => setRoomMembersOpen(true)}
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-border/80 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/40"
+                        >
+                          <Users className="h-3.5 w-3.5" />
+                          Members
+                        </button>
+                      </div>
                     </div>
                   </header>
+
+                  {/* Collapsible message search bar */}
+                  <MessageSearchBar
+                    isVisible={messageSearchOpen}
+                    value={messageSearchQuery}
+                    onChange={setMessageSearchQuery}
+                    onClose={handleCloseSearch}
+                    resultCount={filteredMessages.length}
+                  />
 
                   <div className="px-4 sm:px-5 pt-3">
                     <RoomActivityPanel roomId={selectedChatId} />
@@ -620,8 +671,8 @@ export default function ChatPage() {
                        </div>
                      )}
 
-                     {/* Beginning of conversation indicator */}
-                     {!hasMoreMessages[selectedChatId || ''] && messages.length > 0 && (
+                     {/* Beginning of conversation indicator — only when not searching */}
+                     {!messageSearchQuery.trim() && !hasMoreMessages[selectedChatId || ''] && messages.length > 0 && (
                        <p className="text-center text-muted-foreground text-xs py-2">
                          Beginning of conversation
                        </p>
@@ -639,8 +690,18 @@ export default function ChatPage() {
                        </div>
                      )}
 
+                     {/* Search: no results state */}
                      {!isLoadingMessagesByRoom[selectedChatId || ''] &&
-                       messages.map((message) => (
+                       messageSearchQuery.trim() &&
+                       filteredMessages.length === 0 && (
+                         <div className="h-full flex flex-col items-center justify-center gap-2 text-muted-foreground">
+                           <Search className="h-8 w-8 opacity-30" />
+                           <p className="text-sm">No messages match &ldquo;{messageSearchQuery}&rdquo;</p>
+                         </div>
+                       )}
+
+                     {!isLoadingMessagesByRoom[selectedChatId || ''] &&
+                       filteredMessages.map((message) => (
                          <div
                            key={message.id}
                            className={cn(
@@ -651,7 +712,7 @@ export default function ChatPage() {
                            )}
                          >
                            <p className="whitespace-pre-wrap break-words leading-relaxed">
-                             {message.text}
+                             {highlightText(message.text, messageSearchQuery)}
                            </p>
                            <div
                              className={cn(

--- a/components/message-search-bar.tsx
+++ b/components/message-search-bar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { Search, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MessageSearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClose: () => void;
+  resultCount?: number;
+  isVisible: boolean;
+}
+
+export function MessageSearchBar({
+  value,
+  onChange,
+  onClose,
+  resultCount,
+  isVisible,
+}: MessageSearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus when the bar becomes visible
+  useEffect(() => {
+    if (isVisible) {
+      // Small delay so the CSS transition doesn't fight focus
+      const id = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(id);
+    }
+  }, [isVisible]);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isVisible) {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isVisible, onClose]);
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden transition-all duration-200 ease-out",
+        isVisible ? "max-h-14 opacity-100" : "max-h-0 opacity-0 pointer-events-none",
+      )}
+    >
+      <div className="px-4 sm:px-5 py-2 border-b border-border/70 bg-card/50 backdrop-blur-sm">
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder="Search messages…"
+              className="w-full rounded-xl border border-border/80 bg-background/70 pl-8 pr-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30 placeholder:text-muted-foreground"
+            />
+          </div>
+
+          {/* Result count badge */}
+          {value.trim() && (
+            <span className="shrink-0 text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+              {resultCount === 0
+                ? "No results"
+                : `${resultCount} result${resultCount !== 1 ? "s" : ""}`}
+            </span>
+          )}
+
+          {/* Close button */}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close search"
+            className="shrink-0 inline-flex items-center justify-center h-7 w-7 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/highlight-text.tsx
+++ b/lib/highlight-text.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+/**
+ * Splits `text` into segments and wraps each segment that matches `query`
+ * in a <mark> element for visual highlighting.
+ *
+ * Returns the original text as a plain string when query is empty/blank,
+ * so callers can short-circuit rendering if needed.
+ */
+export function highlightText(
+  text: string,
+  query: string,
+): React.ReactNode {
+  if (!query.trim()) return text;
+
+  // Escape special regex characters in the query so user input is treated literally
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(${escaped})`, "gi");
+  const parts = text.split(regex);
+
+  if (parts.length === 1) return text;
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        regex.test(part) ? (
+          <mark
+            key={i}
+            className="bg-yellow-300/80 text-yellow-900 dark:bg-yellow-400/40 dark:text-yellow-100 rounded-sm px-0.5"
+          >
+            {part}
+          </mark>
+        ) : (
+          part
+        ),
+      )}
+    </>
+  );
+}


### PR DESCRIPTION


- Add MessageSearchBar component with collapsible slide-in animation,
  live result count, Escape-to-close, and auto-focus on open
- Add highlightText utility that wraps matched substrings in <mark>
  with light/dark-mode-aware yellow highlight styling
- Wire search state into chat/page.tsx: filteredMessages memo,
  Search toggle button in conversation header (aria-pressed),
  per-room search reset on room switch, and no-results empty state
- Message feed renders filteredMessages with keyword highlights;
  'Beginning of conversation' indicator hidden while searching

Closes #147 
