### PR TITLE
feat: infinite scroll for chat messages

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -3,8 +3,8 @@ import { MessageList } from './MessageList';
 import { MessageInput } from './MessageInput';
 import { useMessages } from '../hooks/useMessages';
 import { useChatSubscription } from '../hooks/useChatSubscription';
-import { Settings } from 'lucide-react'; // Import the toggle icon
-import { GroupSettingsPanel } from './GroupSettingsPanel'; // Import our new panel
+import { Settings } from 'lucide-react';
+import { GroupSettingsPanel } from './GroupSettingsPanel';
 
 interface Props {
   walletAddress: string;
@@ -19,14 +19,16 @@ export const ChatWindow: React.FC<Props> = ({
   onSendToChain,
   roomId
 }) => {
-  const [isPanelOpen, setIsPanelOpen] = useState(false); // State to open/close drawer
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
 
   const {
     messages,
     addMessage,
     loadMoreMessages,
     isLoading,
-    hasMore
+    isLoadingMore,
+    hasMore,
+    firstMessageId,
   } = useMessages({ roomId, pageSize: 50 });
 
   useChatSubscription(sdk, addMessage);
@@ -40,13 +42,10 @@ export const ChatWindow: React.FC<Props> = ({
     }
   }, [addMessage, walletAddress, onSendToChain]);
 
-  // Derive a dynamic presentation room name or fall back cleanly
-  const currentRoomName = roomId ? `Room: ${roomId.substring(0, 8)}...` : "Main Anonymous Chat";
+  const currentRoomName = roomId ? `Room: ${roomId.substring(0, 8)}...` : 'Main Anonymous Chat';
 
   return (
     <div className='flex flex-col h-full bg-gray-950 text-gray-100 relative overflow-hidden'>
-      
-      {/* Dynamic Group Top Header Block */}
       <div className="w-full h-14 bg-gray-900 border-b border-gray-800 px-6 flex items-center justify-between shadow-sm shrink-0">
         <div className="flex flex-col">
           <span className="font-bold text-sm tracking-wide text-gray-100">{currentRoomName}</span>
@@ -55,8 +54,6 @@ export const ChatWindow: React.FC<Props> = ({
             End-to-End Encrypted
           </span>
         </div>
-        
-        {/* Info/Settings Action Trigger */}
         <button
           onClick={() => setIsPanelOpen(true)}
           className="p-2 bg-gray-800/40 hover:bg-gray-800 border border-gray-800 hover:border-gray-700 text-gray-400 hover:text-purple-400 rounded-xl transition-all shadow-sm group"
@@ -66,19 +63,18 @@ export const ChatWindow: React.FC<Props> = ({
         </button>
       </div>
 
-      {/* Messages Feed View Container */}
       <MessageList
         messages={messages}
         onLoadMore={loadMoreMessages}
         isLoading={isLoading}
+        isLoadingMore={isLoadingMore}
         hasMore={hasMore}
+        firstMessageId={firstMessageId}
       />
-      
-      {/* Message Chat Field Box */}
+
       <MessageInput onSend={handleSend} />
 
-      {/* Embedded Group Settings Slide Drawer Component */}
-      <GroupSettingsPanel 
+      <GroupSettingsPanel
         isOpen={isPanelOpen}
         onClose={() => setIsPanelOpen(false)}
         roomName={currentRoomName}


### PR DESCRIPTION
## Summary

Completes the infinite scroll implementation for chat messages by wiring the missing props (isLoadingMore, irstMessageId) from useMessages into ChatWindow, which then passes them to MessageList.

## What was missing

ChatWindow was only forwarding messages, onLoadMore, isLoading, and hasMore to MessageList. The two props that control scroll-position restoration and the loading spinner during pagination - isLoadingMore and irstMessageId - were not being passed, so the feature was incomplete.

## Changes

- src/components/ChatWindow.tsx - destructure isLoadingMore and irstMessageId from useMessages and forward them to MessageList

No changes to useMessages or MessageList were needed; the logic was already correct.

## Behaviour

- Scrolling to the top triggers IntersectionObserver ? calls loadMoreMessages ? fetches older messages
- Scroll position is restored to the first previously-visible message after load (via irstMessageId + scrollIntoView)
- Spinner shown at the top while older messages are loading (isLoadingMore)
- Duplicate loads prevented by loadingRef guard in useMessages

closes #151