### PR TITLE
feat: add chat appearance settings with multiple color themes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { ThemeProvider } from "@/components/theme-provider";
+import { ChatThemeProvider } from "@/lib/chat-theme";
 import { WebSocketProvider } from "@/lib/websocket/context"
 
 // installed the proper toast module
@@ -51,9 +52,11 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <WebSocketProvider>
-            {children}
-          </WebSocketProvider>
+          <ChatThemeProvider>
+            <WebSocketProvider>
+              {children}
+            </WebSocketProvider>
+          </ChatThemeProvider>
         </ThemeProvider>
         <Analytics />
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 import { Menu, X } from "lucide-react"
 import { useState } from "react"
 import ConnectWallet from "./wallet-connector"
-import { ThemeToggle } from "./theme-toggle"
+import { ThemeSettingsModal } from "./theme-settings-modal"
 import { CreateGroupModal } from "./create-group-modal"
 import { JoinGroupModal } from "./join-group-modal"
 import { NotificationPanel } from "./NotificationPanel"
@@ -49,7 +49,7 @@ export function Header() {
 
         {/* CTA Buttons */}
         <div className="hidden md:flex items-center gap-3">
-          <ThemeToggle />
+          <ThemeSettingsModal />
           <NotificationPanel />
           <CreateGroupModal />
           <JoinGroupModal />
@@ -96,7 +96,7 @@ export function Header() {
             <div className="pt-3 border-t border-border/50 space-y-2">
               <div className="flex items-center justify-between px-2">
                 <span className="text-sm text-muted-foreground font-medium">Theme</span>
-                <ThemeToggle />
+                <ThemeSettingsModal />
               </div>
               <div className="flex items-center justify-between px-2">
                 <span className="text-sm text-muted-foreground font-medium">Notifications</span>

--- a/components/theme-settings-modal.tsx
+++ b/components/theme-settings-modal.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { Moon, Palette, Sun, X } from "lucide-react";
+import { useState } from "react";
+import { useTheme } from "next-themes";
+import { useChatTheme } from "@/lib/chat-theme";
+import { cn } from "@/lib/utils";
+
+export function ThemeSettingsModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const { theme, setTheme } = useTheme();
+  const { colorThemeId, setColorTheme, themes } = useChatTheme();
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
+      <Dialog.Trigger asChild>
+        <button
+          className="p-2 rounded-lg hover:bg-muted transition-colors"
+          aria-label="Appearance settings"
+        >
+          <Palette className="w-5 h-5" />
+        </button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-[50%] top-[50%] z-50 w-full max-w-md translate-x-[-50%] translate-y-[-50%] border border-border/50 bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl">
+          <div className="flex items-start justify-between mb-5">
+            <div>
+              <Dialog.Title className="text-lg font-semibold">Appearance</Dialog.Title>
+              <Dialog.Description className="text-sm text-muted-foreground mt-0.5">
+                Customize how AnonChat looks for you.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close className="mt-0.5 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </Dialog.Close>
+          </div>
+
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-sm font-medium mb-2.5">Mode</h3>
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  onClick={() => setTheme("light")}
+                  className={cn(
+                    "flex items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm transition-all",
+                    theme === "light"
+                      ? "border-primary bg-primary/10 text-foreground font-medium"
+                      : "border-border/60 text-muted-foreground hover:bg-muted/40"
+                  )}
+                >
+                  <Sun className="h-4 w-4 shrink-0" />
+                  Light
+                </button>
+                <button
+                  onClick={() => setTheme("dark")}
+                  className={cn(
+                    "flex items-center justify-center gap-2 rounded-xl border px-4 py-3 text-sm transition-all",
+                    theme === "dark"
+                      ? "border-primary bg-primary/10 text-foreground font-medium"
+                      : "border-border/60 text-muted-foreground hover:bg-muted/40"
+                  )}
+                >
+                  <Moon className="h-4 w-4 shrink-0" />
+                  Dark
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-medium mb-2.5">Color Theme</h3>
+              <div className="flex flex-col gap-2">
+                {themes.map((colorTheme) => {
+                  const isActive = colorThemeId === colorTheme.id;
+                  return (
+                    <button
+                      key={colorTheme.id}
+                      onClick={() => setColorTheme(colorTheme.id)}
+                      className={cn(
+                        "flex items-center gap-3 rounded-xl border px-4 py-3 text-sm transition-all text-left",
+                        isActive
+                          ? "border-primary bg-primary/10"
+                          : "border-border/60 hover:bg-muted/40"
+                      )}
+                    >
+                      <div className="flex gap-1 shrink-0">
+                        <span
+                          className="w-4 h-4 rounded-full ring-1 ring-black/10"
+                          style={{ backgroundColor: colorTheme.preview.primary }}
+                        />
+                        <span
+                          className="w-4 h-4 rounded-full ring-1 ring-black/10"
+                          style={{ backgroundColor: colorTheme.preview.secondary }}
+                        />
+                        <span
+                          className="w-4 h-4 rounded-full ring-1 ring-black/10"
+                          style={{ backgroundColor: colorTheme.preview.accent }}
+                        />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className={cn("text-sm leading-none", isActive ? "text-foreground font-medium" : "text-foreground/80")}>
+                          {colorTheme.name}
+                        </p>
+                        <p className="text-xs text-muted-foreground mt-0.5">{colorTheme.description}</p>
+                      </div>
+                      <span
+                        className={cn(
+                          "ml-auto shrink-0 h-4 w-4 rounded-full border-2 transition-all",
+                          isActive
+                            ? "border-primary bg-primary"
+                            : "border-border/60 bg-transparent"
+                        )}
+                      />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/lib/chat-theme.tsx
+++ b/lib/chat-theme.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+
+export type ColorThemeId = "purple" | "ocean" | "sunset" | "forest" | "midnight";
+
+export type ColorTheme = {
+  id: ColorThemeId;
+  name: string;
+  description: string;
+  preview: {
+    primary: string;
+    secondary: string;
+    accent: string;
+  };
+  vars: Record<string, string>;
+};
+
+export const COLOR_THEMES: ColorTheme[] = [
+  {
+    id: "purple",
+    name: "Purple",
+    description: "Vibrant purple with cyan highlights",
+    preview: { primary: "#9333ea", secondary: "#0891b2", accent: "#d946ef" },
+    vars: {
+      "--primary": "oklch(0.6 0.25 280)",
+      "--secondary": "oklch(0.5 0.2 200)",
+      "--accent": "oklch(0.7 0.22 300)",
+    },
+  },
+  {
+    id: "ocean",
+    name: "Ocean",
+    description: "Deep blue with teal and coral",
+    preview: { primary: "#1d4ed8", secondary: "#0d9488", accent: "#f97316" },
+    vars: {
+      "--primary": "oklch(0.55 0.22 220)",
+      "--secondary": "oklch(0.58 0.18 175)",
+      "--accent": "oklch(0.65 0.2 30)",
+    },
+  },
+  {
+    id: "sunset",
+    name: "Sunset",
+    description: "Warm amber with red and gold",
+    preview: { primary: "#d97706", secondary: "#dc2626", accent: "#ca8a04" },
+    vars: {
+      "--primary": "oklch(0.65 0.22 50)",
+      "--secondary": "oklch(0.58 0.24 25)",
+      "--accent": "oklch(0.75 0.2 75)",
+    },
+  },
+  {
+    id: "forest",
+    name: "Forest",
+    description: "Natural green with emerald and lime",
+    preview: { primary: "#15803d", secondary: "#059669", accent: "#65a30d" },
+    vars: {
+      "--primary": "oklch(0.52 0.18 145)",
+      "--secondary": "oklch(0.6 0.18 165)",
+      "--accent": "oklch(0.68 0.2 120)",
+    },
+  },
+  {
+    id: "midnight",
+    name: "Midnight",
+    description: "Deep indigo with violet and blue",
+    preview: { primary: "#4338ca", secondary: "#7c3aed", accent: "#2563eb" },
+    vars: {
+      "--primary": "oklch(0.55 0.23 260)",
+      "--secondary": "oklch(0.6 0.22 290)",
+      "--accent": "oklch(0.62 0.2 240)",
+    },
+  },
+];
+
+const STORAGE_KEY = "anonchat-color-theme";
+
+type ChatThemeContextValue = {
+  colorThemeId: ColorThemeId;
+  setColorTheme: (id: ColorThemeId) => void;
+  themes: ColorTheme[];
+};
+
+const ChatThemeContext = createContext<ChatThemeContextValue>({
+  colorThemeId: "purple",
+  setColorTheme: () => {},
+  themes: COLOR_THEMES,
+});
+
+function applyThemeVars(theme: ColorTheme) {
+  const root = document.documentElement;
+  for (const [prop, value] of Object.entries(theme.vars)) {
+    root.style.setProperty(prop, value);
+  }
+}
+
+export function ChatThemeProvider({ children }: { children: React.ReactNode }) {
+  const [colorThemeId, setColorThemeId] = useState<ColorThemeId>("purple");
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY) as ColorThemeId | null;
+    const theme = COLOR_THEMES.find((t) => t.id === saved) ?? COLOR_THEMES[0];
+    setColorThemeId(theme.id);
+    applyThemeVars(theme);
+  }, []);
+
+  const setColorTheme = useCallback((id: ColorThemeId) => {
+    const theme = COLOR_THEMES.find((t) => t.id === id);
+    if (!theme) return;
+    setColorThemeId(id);
+    localStorage.setItem(STORAGE_KEY, id);
+    applyThemeVars(theme);
+  }, []);
+
+  return (
+    <ChatThemeContext.Provider value={{ colorThemeId, setColorTheme, themes: COLOR_THEMES }}>
+      {children}
+    </ChatThemeContext.Provider>
+  );
+}
+
+export function useChatTheme() {
+  return useContext(ChatThemeContext);
+}


### PR DESCRIPTION
# 📌 Pull Request

## 🔗 Related Issue

Closes #183

---

## 📝 Description

- Adds a unified **Appearance** modal accessible from the header (palette icon) that lets users pick both a color theme and dark/light mode — all without a page refresh.
- The existing `ThemeToggle` button provided only dark/light switching; there was no way to customize the accent color palette. This PR satisfies the issue requirement to support multiple color themes and persist the preference locally.

---

## 🚀 Changes Made

- [x] Feature implemented: Theme settings modal with 5 color themes (Purple, Ocean, Sunset, Forest, Midnight) and a Dark/Light mode picker
- [ ] Bug fixed:
- [ ] Refactor:
- [ ] Documentation updated:

**New files:**
- `lib/chat-theme.tsx` — React context (`ChatThemeProvider` + `useChatTheme`) that manages color theme state, persists selection to `localStorage`, and applies the three key CSS custom properties (`--primary`, `--secondary`, `--accent`) as inline styles on the document root so changes are instant
- `components/theme-settings-modal.tsx` — Radix Dialog modal with a Mode section (Light/Dark) and a Color Theme section showing three color swatches per option plus a radio-style active indicator

**Modified files:**
- `app/layout.tsx` — Wraps the provider tree with `ChatThemeProvider` (inside `ThemeProvider`, outside `WebSocketProvider`)
- `components/header.tsx` — Replaces the standalone `ThemeToggle` with `ThemeSettingsModal` in both the desktop nav bar and the mobile slide-out drawer

---

## 🧪 Testing & Validation

- [x] Tested locally
- [x] No runtime errors
- [x] Existing features work as expected
- [x] Edge cases handled

**Validated:**
- Switching color themes updates the UI instantly (no refresh)
- Reloading the page restores the last selected theme from `localStorage`
- Dark and light modes work correctly for every color theme — neutral variables (background, foreground, card, border) are untouched; only accent colors change
- Mobile drawer shows the palette button and the modal opens correctly
- TypeScript type check (`pnpm exec tsc --noEmit`) passes with zero errors

---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes exist (explain below)

The standalone `ThemeToggle` component is no longer rendered in the header, but the component file itself (`components/theme-toggle.tsx`) is kept intact. The new modal surfaces the same dark/light control alongside color theme selection.

---

## 📸 Screenshots (REQUIRED for UI changes)

| Before | After |
| ------ | ----- |
| Header had a sun/moon toggle only | Header has a palette icon that opens the Appearance modal |
| Single dark/light toggle | Unified modal with Mode (Light/Dark) + 5 color theme swatches |
| No color customization | Purple, Ocean, Sunset, Forest, Midnight themes available |

---

## 📋 Contributor Checklist (MANDATORY)

- [x] I was assigned to this issue
- [x] My code follows the project structure and conventions
- [x] I have tested my changes thoroughly
- [x] I did not introduce unnecessary dependencies
- [x] I have linked the issue (`Closes #183`)
- [x] This PR is ready for review

---

## 💡 Notes for Reviewer

- **Key areas to review:** `lib/chat-theme.tsx` — the inline style approach for applying CSS custom properties on `document.documentElement` is intentional; it beats both `:root` and `.dark` class selectors in specificity, which is how theme changes take effect instantly without needing to add/remove classes or re-render the provider tree
- **Known limitations:** There is a brief flash on first load if a non-default theme was saved (the CSS defaults apply until `useEffect` fires and reads `localStorage`). This is acceptable for a chat app behind auth; a `<script>` tag in `<head>` could eliminate it if needed later