### PR TITLE
feat: Chat Message Bubble UI with Sender Differentiation

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -21,6 +21,7 @@ import ConnectWallet from "@/components/wallet-connector";
 import { RoomActivityPanel } from "@/components/room-activity-panel";
 import { MessageSearchBar } from "@/components/message-search-bar";
 import { GroupVerificationBadge } from "@/components/GroupVerificationBadge";
+import { ChatMessageBubble, type ChatMessage } from "@/components/chat-message-bubble";
 import { cn } from "@/lib/utils";
 import { highlightText } from "@/lib/highlight-text";
 import { handleAppError } from "@/lib/error-handler"; // Integrated Error Handler
@@ -48,13 +49,7 @@ type ChatPreview = {
   status: PresenceStatus;
 };
 
-type ChatMessage = {
-  id: string;
-  author: "me" | "them";
-  text: string;
-  time: string;
-  status: "sending" | "sent" | "delivered" | "read";
-};
+
 
 interface DBRoom {
   id: string;
@@ -749,34 +744,11 @@ export default function ChatPage() {
 
                      {!isLoadingMessagesByRoom[selectedChatId || ''] &&
                        filteredMessages.map((message) => (
-                         <div
-                           key={message.id}
-                           className={cn(
-                             "max-w-[85%] sm:max-w-[72%] rounded-2xl px-4 py-2.5 shadow-sm text-sm",
-                             message.author === "me"
-                               ? "ml-auto bg-primary text-primary-foreground rounded-br-sm"
-                               : "mr-auto bg-card border border-border/70 rounded-bl-sm",
-                           )}
-                         >
-                           <p className="whitespace-pre-wrap break-words leading-relaxed">
-                             {highlightText(message.text, messageSearchQuery)}
-                           </p>
-                           <div
-                             className={cn(
-                               "mt-1 flex items-center justify-end gap-1 text-[10px]",
-                               message.author === "me"
-                                 ? "text-primary-foreground/80"
-                                 : "text-muted-foreground",
-                             )}
-                           >
-                             <span>{message.time}</span>
-                             {message.author === "me" && (
-                               <span>
-                                 {message.status === "sending" ? "..." : "✓✓"}
-                               </span>
-                             )}
-                           </div>
-                         </div>
+                         <ChatMessageBubble 
+                           key={message.id} 
+                           message={message} 
+                           searchQuery={messageSearchQuery} 
+                         />
                        ))}
                    </div>
 

--- a/components/chat-message-bubble.tsx
+++ b/components/chat-message-bubble.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import { highlightText } from "@/lib/highlight-text";
+
+export type ChatMessage = {
+  id: string;
+  author: "me" | "them";
+  text: string;
+  time: string;
+  status: "sending" | "sent" | "delivered" | "read";
+};
+
+interface ChatMessageBubbleProps {
+  message: ChatMessage;
+  searchQuery?: string;
+}
+
+export function ChatMessageBubble({ message, searchQuery = "" }: ChatMessageBubbleProps) {
+  const isMe = message.author === "me";
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col max-w-[85%] sm:max-w-[72%]",
+        isMe ? "items-end ml-auto" : "items-start mr-auto"
+      )}
+    >
+      <div
+        className={cn(
+          "rounded-2xl px-4 py-2.5 shadow-sm text-sm",
+          isMe
+            ? "bg-primary text-primary-foreground rounded-br-sm"
+            : "bg-card border border-border/70 rounded-bl-sm"
+        )}
+      >
+        <p className="whitespace-pre-wrap break-words leading-relaxed">
+          {highlightText(message.text, searchQuery)}
+        </p>
+      </div>
+      
+      <div className="mt-1 flex items-center gap-1 text-[10px] text-muted-foreground">
+        <span>{message.time}</span>
+        {isMe && (
+          <span>{message.status === "sending" ? "..." : "✓✓"}</span>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #104 

# Summary of Changes
- Created a new dedicated component `components/chat-message-bubble.tsx`.
- Extracted and cleaned up the inline message rendering logic in `app/chat/page.tsx`.
- Updated message layout to explicitly move timestamps beneath the message bubbles.


## Reason for the Changes
This PR addresses **Issue #104**. Previously, the chat interface lacked visual distinction, and the timestamps were rendered awkwardly inside the message text bubbles. This update separates the chat bubble rendering into a modular component, ensuring messages are visually aligned (right for "me", left for "them") with distinct colors, and places the metadata (timestamp and status) neatly below each message. Abstracting the logic also drastically reduces boilerplate within the monolithic `page.tsx` file.