### PR TITLE
feat(stellar): fix #132 by adding memo-based group identification

### DIFF
--- a/app/api/rooms/[roomId]/route.ts
+++ b/app/api/rooms/[roomId]/route.ts
@@ -6,6 +6,8 @@ import { resolveRoomOwnerWallet } from "@/lib/auth/wallet-owner";
 import { computeHash } from "@/lib/blockchain/metadata-hash";
 import { submitMetadataHash, getTransactionExplorerUrl } from "@/lib/blockchain/stellar-service";
 import { GroupMetadata } from "@/types/blockchain";
+import { persistGroupTransactionMemo } from "@/lib/blockchain/memo-store";
+import { type SupabaseClient } from "@supabase/supabase-js";
 
 export async function GET(
   request: NextRequest,
@@ -157,6 +159,14 @@ export async function PATCH(
             memo_group_id: result.memoGroupId ?? null,
           })
           .eq("id", roomId);
+
+        if (result.memoGroupId) {
+          await persistGroupTransactionMemo(supabase as unknown as SupabaseClient, {
+            groupId: roomId,
+            memoGroupId: result.memoGroupId,
+            txHash: stellarTxHash,
+          });
+        }
       }
     } catch (blockchainError: any) {
       console.error("[rooms/[roomId]] PATCH blockchain submission error:", blockchainError);

--- a/app/api/rooms/route.ts
+++ b/app/api/rooms/route.ts
@@ -18,6 +18,7 @@ import {
 import { getTransaction } from "@/lib/blockchain/stellar-service";
 import { insertRoomActivity } from "@/lib/activity/room-activity";
 import { type SupabaseClient } from "@supabase/supabase-js";
+import { persistGroupTransactionMemo } from "@/lib/blockchain/memo-store";
 
 export async function GET(request: NextRequest) {
   try {
@@ -204,13 +205,14 @@ export async function POST(request: NextRequest) {
 
         // Persist the groupId <-> transactionId mapping for fast lookups
         if (result.memoGroupId) {
-          const { error: memoInsertError } = await supabase
-            .from("group_tx_memos")
-            .insert({
-              group_id: room.id,
-              memo_group_id: result.memoGroupId,
-              tx_hash: stellarTxHash,
-            });
+          const { error: memoInsertError } = await persistGroupTransactionMemo(
+            supabase as unknown as SupabaseClient,
+            {
+              groupId: room.id,
+              memoGroupId: result.memoGroupId,
+              txHash: stellarTxHash,
+            },
+          );
 
           if (memoInsertError) {
             // Non-fatal: log but don't fail the request

--- a/app/api/stellar/memo/route.ts
+++ b/app/api/stellar/memo/route.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/stellar/memo?memo=grp_abc123xyz
+ * GET /api/stellar/memo?memo=grp_2f4a7c9b0e1d6a8c3f5b9d0a
  *
  * Looks up a group by its Stellar memo identifier.
  * Returns the room record and the associated transaction hash.
@@ -23,7 +23,6 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const memo = searchParams.get("memo");
 
-  // ── 1. Validate memo parameter ──────────────────────────────────────────────
   if (!memo) {
     return NextResponse.json(
       { error: "memo query parameter is required" },
@@ -49,11 +48,12 @@ export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
 
-    // ── 2. Look up via the fast lookup table first ──────────────────────────
     const { data: memoRecord, error: memoError } = await supabase
       .from("group_tx_memos")
       .select("group_id, tx_hash, created_at")
       .eq("memo_group_id", memo)
+      .order("created_at", { ascending: false })
+      .limit(1)
       .maybeSingle();
 
     if (memoError) {
@@ -73,7 +73,6 @@ export async function GET(request: NextRequest) {
     }
 
     if (!memoRecord) {
-      // ── 3. Fallback: query rooms table directly ─────────────────────────
       const { data: room, error: roomError } = await supabase
         .from("rooms")
         .select(
@@ -122,7 +121,6 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // ── 4. Fetch the full room record ───────────────────────────────────────
     const { data: room, error: roomError } = await supabase
       .from("rooms")
       .select("id, name, description, is_private, created_at")

--- a/lib/blockchain/audit.ts
+++ b/lib/blockchain/audit.ts
@@ -147,6 +147,29 @@ export async function recordGroupAuditEvent({
       }, correlationId);
     }
 
+    if (result.auditMemo) {
+      const { error: memoInsertError } = await supabase
+        .from("group_tx_memos")
+        .insert({
+          group_id: groupId,
+          memo_group_id: result.auditMemo,
+          tx_hash: result.transactionHash,
+        });
+
+      if (memoInsertError) {
+        logBlockchainOperation("warn", "Audit transaction memo mapping failed", {
+          groupId,
+          eventId,
+          eventType,
+          transactionHash: result.transactionHash,
+          error: {
+            type: "DatabaseError",
+            message: memoInsertError.message,
+          },
+        }, correlationId);
+      }
+    }
+
     return {
       eventId,
       eventType,

--- a/lib/blockchain/group-verification.test.ts
+++ b/lib/blockchain/group-verification.test.ts
@@ -134,6 +134,51 @@ describe("group verification logic", () => {
     expect(result.error).toBeNull();
   });
 
+  it("accepts Stellar memo type values returned as MEMO_TEXT", () => {
+    const metadata = buildGroupMetadata(baseRoom);
+    const transaction: StellarTransaction = {
+      hash: baseRoom.stellar_tx_hash!,
+      memo: deriveMemoGroupId(baseRoom.id),
+      memoType: "MEMO_TEXT",
+      ledger: 1,
+      created_at: "2026-01-01T00:00:00.000Z",
+    };
+
+    const result = evaluateGroupVerification(
+      {
+        ...baseRoom,
+        metadata_hash: computeHash(metadata),
+      },
+      transaction,
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.memoVerified).toBe(true);
+  });
+
+  it("rejects matching group memos when Stellar memo type is not text", () => {
+    const metadata = buildGroupMetadata(baseRoom);
+    const transaction: StellarTransaction = {
+      hash: baseRoom.stellar_tx_hash!,
+      memo: deriveMemoGroupId(baseRoom.id),
+      memoType: "MEMO_HASH",
+      ledger: 1,
+      created_at: "2026-01-01T00:00:00.000Z",
+    };
+
+    const result = evaluateGroupVerification(
+      {
+        ...baseRoom,
+        metadata_hash: computeHash(metadata),
+      },
+      transaction,
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.memoVerified).toBe(false);
+    expect(result.error).toContain("text memo");
+  });
+
   it("cannot spoof verification by omitting anchored metadata hash", () => {
     const transaction: StellarTransaction = {
       hash: baseRoom.stellar_tx_hash!,

--- a/lib/blockchain/group-verification.ts
+++ b/lib/blockchain/group-verification.ts
@@ -125,6 +125,20 @@ export function evaluateGroupVerification(
     };
   }
 
+  const memoType = transaction.memoType?.toLowerCase();
+  if (memoType && memoType !== "text" && memoType !== "memo_text") {
+    return {
+      verified: false,
+      memoVerified: false,
+      walletOwnershipVerified: false,
+      currentMetadataHash,
+      blockchainMetadataHash,
+      transactionHash,
+      walletAddress,
+      error: "On-chain transaction memo must be a text memo",
+    };
+  }
+
   const memoVerified = memoMatchesGroup(room.id, transaction.memo);
   if (!memoVerified) {
     return {

--- a/lib/blockchain/memo-middleware.ts
+++ b/lib/blockchain/memo-middleware.ts
@@ -3,7 +3,7 @@
  *
  * Use `withMemoValidation` to wrap any route handler that receives a
  * `memoGroupId` in the request body or query string.  The middleware
- * validates the memo format and — when a `groupId` is also present —
+ * validates the memo format and, when a `groupId` is also present,
  * verifies that the memo matches the expected value for that group.
  *
  * Usage (in a route handler):
@@ -15,11 +15,13 @@
  */
 
 import { NextResponse } from "next/server";
+import { type SupabaseClient } from "@supabase/supabase-js";
 import {
   validateMemoGroupId,
   deriveMemoGroupId,
   memoMatchesGroup,
 } from "./memo";
+import { validateStoredGroupMemo } from "./memo-store";
 
 export interface MemoValidationResult {
   valid: boolean;
@@ -57,6 +59,18 @@ export function validateRequestMemo(
   }
 
   return { valid: true };
+}
+
+export async function validateRequestMemoForStoredGroup(
+  supabase: SupabaseClient,
+  memo: unknown,
+  groupId: string,
+): Promise<MemoValidationResult> {
+  if (typeof memo !== "string") {
+    return { valid: false, reason: "memo must be a non-empty string" };
+  }
+
+  return validateStoredGroupMemo(supabase, groupId, memo);
 }
 
 /**

--- a/lib/blockchain/memo-store.ts
+++ b/lib/blockchain/memo-store.ts
@@ -1,0 +1,67 @@
+import { type SupabaseClient } from "@supabase/supabase-js";
+import { memoMatchesGroup, validateMemoGroupId } from "./memo";
+
+export interface GroupMemoMapping {
+  groupId: string;
+  memoGroupId: string;
+  txHash: string;
+}
+
+export interface GroupMemoValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export async function persistGroupTransactionMemo(
+  supabase: SupabaseClient,
+  mapping: GroupMemoMapping,
+): Promise<{ error: Error | null }> {
+  const validation = await validateStoredGroupMemo(
+    supabase,
+    mapping.groupId,
+    mapping.memoGroupId,
+  );
+
+  if (!validation.valid) {
+    return { error: new Error(validation.reason ?? "Invalid group memo") };
+  }
+
+  const { error } = await supabase.from("group_tx_memos").insert({
+    group_id: mapping.groupId,
+    memo_group_id: mapping.memoGroupId,
+    tx_hash: mapping.txHash,
+  });
+
+  return { error: error ? new Error(error.message) : null };
+}
+
+export async function validateStoredGroupMemo(
+  supabase: SupabaseClient,
+  groupId: string,
+  memoGroupId: string,
+): Promise<GroupMemoValidationResult> {
+  const validation = validateMemoGroupId(memoGroupId);
+  if (!validation.valid) {
+    return validation;
+  }
+
+  if (!memoMatchesGroup(groupId, memoGroupId)) {
+    return { valid: false, reason: "memo does not match group ID" };
+  }
+
+  const { data: room, error } = await supabase
+    .from("rooms")
+    .select("id")
+    .eq("id", groupId)
+    .maybeSingle();
+
+  if (error) {
+    return { valid: false, reason: "failed to validate group record" };
+  }
+
+  if (!room) {
+    return { valid: false, reason: "group does not exist" };
+  }
+
+  return { valid: true };
+}

--- a/lib/blockchain/memo.ts
+++ b/lib/blockchain/memo.ts
@@ -1,49 +1,33 @@
 /**
  * Stellar memo utilities for group identification.
  *
- * Stellar's TEXT memo is limited to 28 bytes (UTF-8).  We derive a compact,
- * deterministic memo from the room ID so that every on-chain transaction can
- * be traced back to a specific group without requiring custom contracts or
- * extra fields.
+ * Stellar's TEXT memo is limited to 28 bytes. We derive a compact deterministic
+ * memo from the room ID so every on-chain transaction can be traced back to a
+ * specific group without custom contracts or extra fields.
  *
- * Memo format:  "grp_<12-char-slug>"   (17 bytes, well within the 28-byte cap)
- *
- * The 12-char slug is the first 12 characters of the base-36 representation of
- * the room's creation timestamp + random suffix, extracted directly from the
- * existing room ID format:  room_{timestamp}_{random9chars}
- *
- * If the room ID does not follow that pattern we fall back to a truncated
- * SHA-256 hex of the full room ID (first 24 hex chars → 12 bytes of entropy).
+ * Memo format: "grp_<24 lowercase hex chars>"
  */
 
-import { createHash } from "crypto";
+import { createHash, timingSafeEqual } from "crypto";
 
 /** Maximum byte length allowed by Stellar for TEXT memos. */
 export const STELLAR_MEMO_MAX_BYTES = 28;
 
 /** Prefix that identifies AnonChat group memos on-chain. */
 const MEMO_PREFIX = "grp_";
+const MEMO_HASH_HEX_LENGTH = 24;
+const MEMO_PATTERN = /^grp_[a-f0-9]{24}$/;
 
 /**
- * Derives a deterministic, ≤28-byte memo string from a room ID.
+ * Derives a deterministic memo string from a room ID.
  *
  * @param roomId - The room's primary key (e.g. "room_1714000000000_abc123xyz")
  * @returns A memo string safe to pass to `StellarSdk.Memo.text()`
  */
 export function deriveMemoGroupId(roomId: string): string {
-  // Try to extract the random suffix from the canonical room ID format
-  const match = roomId.match(/^room_\d+_([a-z0-9]+)$/i);
-  if (match) {
-    // Use up to 12 chars of the random suffix for the slug
-    const slug = match[1].substring(0, 12).toLowerCase();
-    const memo = `${MEMO_PREFIX}${slug}`;
-    return memo.substring(0, STELLAR_MEMO_MAX_BYTES);
-  }
-
-  // Fallback: SHA-256 of the room ID, take first 24 hex chars
-  const hash = createHash("sha256").update(roomId).digest("hex");
-  const memo = `${MEMO_PREFIX}${hash.substring(0, 24)}`;
-  return memo.substring(0, STELLAR_MEMO_MAX_BYTES);
+  const normalizedRoomId = roomId.trim();
+  const hash = createHash("sha256").update(normalizedRoomId).digest("hex");
+  return `${MEMO_PREFIX}${hash.substring(0, MEMO_HASH_HEX_LENGTH)}`;
 }
 
 /**
@@ -51,9 +35,8 @@ export function deriveMemoGroupId(roomId: string): string {
  *
  * Rules:
  *  - Must be a non-empty string
- *  - Must be ≤28 bytes when encoded as UTF-8
- *  - Must start with the "grp_" prefix (AnonChat convention)
- *  - Must contain only printable ASCII characters (Stellar SDK requirement)
+ *  - Must be 28 bytes or less when encoded as UTF-8
+ *  - Must match AnonChat's "grp_<24 lowercase hex chars>" convention
  *
  * @param memo - The memo string to validate
  * @returns `{ valid: true }` or `{ valid: false, reason: string }`
@@ -73,19 +56,10 @@ export function validateMemoGroupId(
     };
   }
 
-  if (!memo.startsWith(MEMO_PREFIX)) {
+  if (!MEMO_PATTERN.test(memo)) {
     return {
       valid: false,
-      reason: `memo must start with "${MEMO_PREFIX}" prefix`,
-    };
-  }
-
-  // Stellar SDK rejects non-printable ASCII in text memos
-  // eslint-disable-next-line no-control-regex
-  if (/[^\x20-\x7E]/.test(memo)) {
-    return {
-      valid: false,
-      reason: "memo must contain only printable ASCII characters",
+      reason: 'memo must match "grp_<24 lowercase hex chars>"',
     };
   }
 
@@ -102,5 +76,11 @@ export function validateMemoGroupId(
  */
 export function memoMatchesGroup(roomId: string, onChainMemo: string): boolean {
   const expected = deriveMemoGroupId(roomId);
-  return expected === onChainMemo;
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const actualBuffer = Buffer.from(onChainMemo, "utf8");
+
+  return (
+    expectedBuffer.length === actualBuffer.length &&
+    timingSafeEqual(expectedBuffer, actualBuffer)
+  );
 }

--- a/lib/blockchain/stellar-service.ts
+++ b/lib/blockchain/stellar-service.ts
@@ -1,25 +1,17 @@
 import * as StellarSdk from "@stellar/stellar-sdk";
-import { StellarTransactionResult, StellarTransaction } from "@/types/blockchain";
+import {
+  AuditEventType,
+  StellarTransactionResult,
+  StellarTransaction,
+} from "@/types/blockchain";
 import { loadStellarConfig, isConfigured, getExplorerUrl } from "./stellar-config";
 import { logBlockchainOperation, generateCorrelationId } from "./logger";
 import { deriveMemoGroupId, validateMemoGroupId, STELLAR_MEMO_MAX_BYTES } from "./memo";
 
-const AUDIT_EVENT_CODES = {
-  group_created: "c",
-  member_joined: "j",
-  member_left: "l",
-  member_removed: "r",
-} as const;
-
-function buildAuditMemo(eventId: string, eventType: keyof typeof AUDIT_EVENT_CODES): string {
-  const compactId = eventId.replace(/-/g, "").slice(0, 21);
-  return `aca_${AUDIT_EVENT_CODES[eventType]}_${compactId}`;
-}
-
 /**
  * Submits a metadata hash to the Stellar blockchain.
  *
- * The Stellar TEXT memo embeds the group's compact identifier (≤28 bytes)
+ * The Stellar TEXT memo embeds the group's compact identifier
  * so that every on-chain transaction is traceable back to a specific group.
  * The metadata hash is stored in the DB for integrity verification; the memo
  * carries the group reference that can be validated independently on-chain.
@@ -79,7 +71,7 @@ export async function submitMetadataHash(
       ),
     ]);
 
-    // Derive the group memo from the room ID (≤28 bytes, "grp_<slug>" format).
+    // Derive the group memo from the room ID.
     // This embeds the group reference directly in the on-chain transaction so
     // it can be validated independently without querying the database.
     const memoGroupId = deriveMemoGroupId(groupId);
@@ -120,7 +112,7 @@ export async function submitMetadataHash(
           amount: "0.0000001", // Minimal amount
         })
       )
-      // Embed the group identifier — not the hash — so the memo is a stable,
+      // Embed the group identifier, not the hash, so the memo is a stable,
       // human-readable group reference that survives metadata changes.
       .addMemo(StellarSdk.Memo.text(memoGroupId))
       .setTimeout(30)
@@ -180,15 +172,14 @@ export async function submitMetadataHash(
 /**
  * Submits an immutable audit marker to Stellar.
  *
- * Stellar TEXT memos are limited to 28 bytes, so the memo stores a compact
- * audit-event reference: "aca_<event-code>_<event-id-prefix>". The complete
- * event payload, metadata hash, transaction hash, and memo are stored in
+ * The Stellar TEXT memo stores the group's compact identifier. The complete
+ * audit event payload, metadata hash, transaction hash, and memo are stored in
  * Supabase for fast lookup and verification.
  */
 export async function submitAuditEvent(
   groupId: string,
   eventId: string,
-  eventType: keyof typeof AUDIT_EVENT_CODES,
+  eventType: AuditEventType,
   metadataHash: string,
   maxFee?: string | number
 ): Promise<StellarTransactionResult> {
@@ -218,11 +209,12 @@ export async function submitAuditEvent(
     };
   }
 
-  const auditMemo = buildAuditMemo(eventId, eventType);
-  if (Buffer.byteLength(auditMemo, "utf8") > STELLAR_MEMO_MAX_BYTES) {
+  const auditMemo = deriveMemoGroupId(groupId);
+  const memoValidation = validateMemoGroupId(auditMemo);
+  if (!memoValidation.valid) {
     return {
       success: false,
-      error: "Audit memo exceeds Stellar memo limit",
+      error: `Audit memo validation failed: ${memoValidation.reason}`,
     };
   }
 
@@ -345,6 +337,7 @@ export async function getTransaction(txHash: string): Promise<StellarTransaction
     return {
       hash: transaction.hash,
       memo: transaction.memo || "",
+      memoType: (transaction as any).memo_type,
       ledger: transaction.ledger_attr,
       created_at: transaction.created_at,
     };

--- a/scripts/011_stellar_memo_group_id.sql
+++ b/scripts/011_stellar_memo_group_id.sql
@@ -1,9 +1,8 @@
 -- Migration: Add Stellar memo group ID support
--- Description: Adds memo_group_id column to rooms and a lookup table for
---              groupId <-> transactionId mapping via Stellar memo field.
+-- Description: Adds memo_group_id column to rooms and a lookup table for Stellar memo transaction mappings.
 -- Date: 2026-04-25
 
--- Add memo_group_id column: the compact ≤28-byte text embedded in the Stellar memo
+-- Add memo_group_id column for the compact text embedded in the Stellar memo
 ALTER TABLE public.rooms
   ADD COLUMN IF NOT EXISTS memo_group_id TEXT NULL;
 
@@ -14,21 +13,25 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_rooms_memo_group_id
 
 -- Add comment
 COMMENT ON COLUMN public.rooms.memo_group_id IS
-  'Compact group identifier (≤28 bytes) embedded in the Stellar transaction memo field';
+  'Compact group identifier embedded in the Stellar transaction memo field';
 
--- ─── Lookup table: group_tx_memos ────────────────────────────────────────────
--- Stores the canonical groupId <-> transactionId mapping for fast lookups
--- without re-querying the blockchain.
+-- Lookup table: group_tx_memos
+-- Stores groupId, memo, and transactionId mappings for fast lookups without re-querying the blockchain.
 CREATE TABLE IF NOT EXISTS public.group_tx_memos (
   id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   group_id      TEXT        NOT NULL REFERENCES public.rooms(id) ON DELETE CASCADE,
   memo_group_id TEXT        NOT NULL,
   tx_hash       TEXT        NOT NULL,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
-  UNIQUE (group_id),
-  UNIQUE (memo_group_id),
   UNIQUE (tx_hash)
 );
+
+-- Drop legacy uniqueness constraints if this migration is reapplied after an earlier draft.
+ALTER TABLE public.group_tx_memos
+  DROP CONSTRAINT IF EXISTS group_tx_memos_group_id_key;
+
+ALTER TABLE public.group_tx_memos
+  DROP CONSTRAINT IF EXISTS group_tx_memos_memo_group_id_key;
 
 -- Indexes for fast lookups in both directions
 CREATE INDEX IF NOT EXISTS idx_group_tx_memos_group_id
@@ -44,11 +47,17 @@ CREATE INDEX IF NOT EXISTS idx_group_tx_memos_tx_hash
 ALTER TABLE public.group_tx_memos ENABLE ROW LEVEL SECURITY;
 
 -- Anyone can read memo mappings (they are public identifiers)
+DROP POLICY IF EXISTS "Anyone can view group tx memos"
+  ON public.group_tx_memos;
+
 CREATE POLICY "Anyone can view group tx memos"
   ON public.group_tx_memos FOR SELECT
   USING (true);
 
 -- Only authenticated users (server-side) can insert
+DROP POLICY IF EXISTS "Authenticated users can insert group tx memos"
+  ON public.group_tx_memos;
+
 CREATE POLICY "Authenticated users can insert group tx memos"
   ON public.group_tx_memos FOR INSERT
   WITH CHECK (auth.role() = 'authenticated');
@@ -56,6 +65,6 @@ CREATE POLICY "Authenticated users can insert group tx memos"
 COMMENT ON TABLE public.group_tx_memos IS
   'Lookup table mapping group IDs to Stellar transaction hashes via the memo field';
 COMMENT ON COLUMN public.group_tx_memos.memo_group_id IS
-  'The exact text stored in the Stellar transaction memo (≤28 bytes)';
+  'The exact text stored in the Stellar transaction memo';
 COMMENT ON COLUMN public.group_tx_memos.tx_hash IS
   'Stellar transaction hash that contains this memo';

--- a/scripts/012_group_audit_events.sql
+++ b/scripts/012_group_audit_events.sql
@@ -29,7 +29,9 @@ create index if not exists group_audit_events_tx_hash_idx
   on public.group_audit_events(transaction_hash)
   where transaction_hash is not null;
 
-create unique index if not exists group_audit_events_stellar_memo_idx
+drop index if exists public.group_audit_events_stellar_memo_idx;
+
+create index if not exists group_audit_events_stellar_memo_idx
   on public.group_audit_events(stellar_memo)
   where stellar_memo is not null;
 
@@ -71,8 +73,8 @@ create policy "Authenticated actors can update their audit events"
 comment on table public.group_audit_events is
   'On-chain audit trail mapping group events to Stellar transaction hashes';
 comment on column public.group_audit_events.event_id is
-  'Stable audit event identifier referenced by the Stellar memo';
+  'Stable audit event identifier stored with the on-chain audit record';
 comment on column public.group_audit_events.transaction_hash is
   'Stellar transaction hash for the on-chain audit marker';
 comment on column public.group_audit_events.stellar_memo is
-  'Compact Stellar memo containing event type and event ID prefix';
+  'Compact Stellar memo containing the group identifier';

--- a/types/blockchain.ts
+++ b/types/blockchain.ts
@@ -14,9 +14,9 @@ export interface StellarTransactionResult {
   success: boolean;
   transactionHash?: string;
   feeCharged?: string;
-  /** The group memo embedded in the Stellar transaction (≤28 bytes). */
+  /** The group memo embedded in the Stellar transaction. */
   memoGroupId?: string;
-  /** The audit memo embedded in the Stellar transaction (≤28 bytes). */
+  /** The audit memo embedded in the Stellar transaction. */
   auditMemo?: string;
   error?: string;
 }
@@ -30,6 +30,7 @@ export type AuditEventType =
 export interface StellarTransaction {
   hash: string;
   memo: string;
+  memoType?: string;
   ledger: number;
   created_at: string;
 }
@@ -80,7 +81,7 @@ export interface GroupCreationResponse {
     stellar_tx_hash: string | null;
     metadata_hash?: string | null;
     blockchain_submitted_at?: string | null;
-    /** Compact group identifier embedded in the Stellar memo (≤28 bytes). */
+    /** Compact group identifier embedded in the Stellar memo. */
     memo_group_id?: string | null;
   };
   success: boolean;


### PR DESCRIPTION
Closes #132 

# PR Description

This PR fixes #132 by making Stellar transaction memos identify AnonChat groups consistently across on-chain group interactions.

Group memos are now derived from the room ID as a deterministic Stellar text memo in the format `grp_<24 lowercase hex chars>`. The memo is exactly 28 ASCII bytes, which fits Stellar's `MEMO_TEXT` limit. Metadata hashes and audit event details remain in the database, while the Stellar memo is reserved for the group reference so it does not conflict with other transaction metadata.

When a group is created, updated, or recorded through an audit event, the Stellar transaction uses the derived group memo. The transaction hash, group ID, and memo are stored in `group_tx_memos` for quick lookup. Memo lookup now resolves the latest transaction mapping for a memo and falls back to the room record when no transaction mapping exists.

The verification flow now retrieves the Stellar transaction memo and memo type from Horizon, accepts valid text memo representations, rejects non-text memos, and compares the on-chain memo against the expected group memo. Memo validation also checks that a supplied memo maps to an existing group record before storing a transaction mapping.

# Changes Made

- Fixed #132 in `lib/blockchain/memo.ts` by replacing suffix-based memo derivation with a deterministic SHA-256 based group memo that fits Stellar `MEMO_TEXT`.
- Fixed the issue in `lib/blockchain/memo-store.ts` by adding shared helpers to validate group memo mappings and persist `groupId`, `memoGroupId`, and `transactionHash`.
- Fixed the issue in `lib/blockchain/stellar-service.ts` by using the group memo for metadata and audit Stellar transactions, and by returning Horizon `memo_type` during transaction retrieval.
- Fixed the issue in `lib/blockchain/group-verification.ts` by rejecting non-text Stellar memos and validating the on-chain memo against the expected group memo.
- Fixed the issue in `lib/blockchain/memo-middleware.ts` by adding stored-group memo validation for request flows that need database-backed integrity checks.
- Fixed the issue in `app/api/rooms/route.ts` and `app/api/rooms/[roomId]/route.ts` by persisting group transaction memo mappings after blockchain submissions.
- Fixed the issue in `lib/blockchain/audit.ts` by storing audit transaction hashes in `group_tx_memos` and using the group memo for audit records.
- Fixed the issue in `app/api/stellar/memo/route.ts` by resolving the latest transaction mapping for a memo and keeping the room fallback.
- Fixed the issue in `scripts/011_stellar_memo_group_id.sql` by allowing multiple transaction mappings per group memo while keeping transaction hashes unique.
- Fixed the issue in `scripts/012_group_audit_events.sql` by changing the audit memo index from unique to non-unique because multiple group events can share the same group memo.
- Fixed #132 in `types/blockchain.ts` by adding `memoType` to retrieved Stellar transactions.
- Added focused coverage in `lib/blockchain/group-verification.test.ts` for `MEMO_TEXT` memo type handling and non-text memo rejection.

# Testing

```bash
git diff --check
```

Result: passed.

```bash
npm run test:unit -- lib/blockchain/group-verification.test.ts
```

Result: could not run because `vitest` is not installed in this workspace (`sh: 1: vitest: not found`).
