### PR TITLE
Feat: Wallet Network Verification (#221)

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -39,6 +39,7 @@ import {
   Users,
 } from "lucide-react";
 import { StellarNetworkStatus } from "@/components/stellar-network-status";
+import { WalletNetworkWarning } from "@/components/wallet-network-warning";
 
 type ChatPreview = {
   id: string;
@@ -490,6 +491,7 @@ export default function ChatPage() {
       <Header />
 
       <StellarNetworkStatus variant="banner" />
+      <WalletNetworkWarning variant="banner" />
 
       <main className="flex-1 pt-24 pb-24 md:pb-8 px-3 sm:px-6">
         <div className="mx-auto w-full max-w-7xl h-[min(84vh,820px)] rounded-3xl border border-border/70 bg-card/90 shadow-[0_24px_64px_-24px_rgba(0,0,0,0.35)] backdrop-blur-sm overflow-hidden">

--- a/app/stellar-wallet-kit.tsx
+++ b/app/stellar-wallet-kit.tsx
@@ -10,6 +10,8 @@ import {
   HanaModule,
 } from "@creit.tech/stellar-wallets-kit";
 
+export type DetectedNetwork = "testnet" | "mainnet" | "unknown";
+
 export { FREIGHTER_ID, ALBEDO_ID };
 
 const SELECTED_WALLET_ID = "selectedWalletId";
@@ -34,6 +36,14 @@ function clearWalletStorage() {
 
 let kit: StellarWalletsKit | null = null;
 
+function getExpectedWalletNetwork(): WalletNetwork {
+  if (typeof process !== "undefined" && process.env.NEXT_PUBLIC_STELLAR_NETWORK) {
+    const env = process.env.NEXT_PUBLIC_STELLAR_NETWORK.toLowerCase();
+    if (env === "testnet") return WalletNetwork.TESTNET;
+  }
+  return WalletNetwork.PUBLIC;
+}
+
 function getKit(): StellarWalletsKit | null {
   if (typeof window === "undefined") return null;
   if (kit) return kit;
@@ -47,7 +57,7 @@ function getKit(): StellarWalletsKit | null {
         new LobstrModule(),
         new HanaModule(),
       ],
-      network: WalletNetwork.PUBLIC,
+      network: getExpectedWalletNetwork(),
       selectedWalletId: getSelectedWalletId() ?? FREIGHTER_ID,
     });
   } catch (e) {
@@ -56,6 +66,49 @@ function getKit(): StellarWalletsKit | null {
   }
 
   return kit;
+}
+
+export function getExpectedNetwork(): DetectedNetwork {
+  const network = getExpectedWalletNetwork();
+  if (network === WalletNetwork.TESTNET) return "testnet";
+  return "mainnet";
+}
+
+export async function detectWalletNetwork(): Promise<DetectedNetwork> {
+  if (typeof window === "undefined") return "unknown";
+
+  const walletId = getSelectedWalletId();
+  if (!walletId) return "unknown";
+
+  try {
+    if (walletId === FREIGHTER_ID) {
+      const module = new FreighterModule();
+      const isAvailable = await module.isAvailable();
+      if (!isAvailable) return "unknown";
+      const { network } = await module.getNetwork();
+      const upper = network.toUpperCase();
+      if (upper === "PUBLIC") return "mainnet";
+      if (upper === "TESTNET" || upper === "TEST") return "testnet";
+      if (network.includes("Test SDF Network")) return "testnet";
+      if (network.includes("Public Global")) return "mainnet";
+      return "unknown";
+    }
+
+    if (walletId === ALBEDO_ID) {
+      const module = new AlbedoModule();
+      const isAvailable = await module.isAvailable();
+      if (!isAvailable) return "unknown";
+      const { network } = await module.getNetwork();
+      const upper = network.toUpperCase();
+      if (upper === "PUBLIC") return "mainnet";
+      if (upper === "TESTNET" || upper === "TEST") return "testnet";
+      return "unknown";
+    }
+  } catch (e) {
+    console.error("Failed to detect wallet network:", e);
+  }
+
+  return "unknown";
 }
 
 export async function signTransaction(...args: any[]) {

--- a/components/create-group-modal.tsx
+++ b/components/create-group-modal.tsx
@@ -3,11 +3,12 @@
 import React, { useState, useEffect } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X, Users, Loader2, Info } from "lucide-react";
-import { getPublicKey, connect } from "@/app/stellar-wallet-kit";
+import { getPublicKey, connect, detectWalletNetwork, getExpectedNetwork } from "@/app/stellar-wallet-kit";
 import { toast } from "react-hot-toast";
 import { trackActivity } from "@/lib/reputation";
 import { shortenWalletAddress } from "@/lib/utils";
 import { WalletAddress } from "@/components/wallet-address";
+import { handleAppError } from "@/lib/error-handler";
 
 export function CreateGroupModal() {
   const [isOpen, setIsOpen] = useState(false);
@@ -67,6 +68,14 @@ export function CreateGroupModal() {
 
     if (!publicKey) {
       toast.error("Please connect your wallet first");
+      return;
+    }
+
+    const walletNet = await detectWalletNetwork();
+    const expectedNet = getExpectedNetwork();
+    if (walletNet !== "unknown" && walletNet !== expectedNet) {
+      const label = expectedNet === "testnet" ? "Testnet" : "Mainnet";
+      handleAppError(new Error(`Switch wallet to ${label} to create groups`), "NETWORK_MISMATCH");
       return;
     }
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,6 +8,7 @@ import { ThemeSettingsModal } from "./theme-settings-modal"
 import { CreateGroupModal } from "./create-group-modal"
 import { JoinGroupModal } from "./join-group-modal"
 import { NotificationPanel } from "./NotificationPanel"
+import { WalletNetworkWarning } from "./wallet-network-warning"
 
 export function Header() {
   const [isOpen, setIsOpen] = useState(false)
@@ -69,6 +70,8 @@ export function Header() {
           {isOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
       </nav>
+
+      <WalletNetworkWarning variant="inline" className="mx-4 mb-2" />
 
       {/* Mobile Navigation */}
       {isOpen && (

--- a/components/wallet-connector.tsx
+++ b/components/wallet-connector.tsx
@@ -4,6 +4,8 @@ import {
   disconnect,
   getPublicKey,
   signMessage,
+  detectWalletNetwork,
+  getExpectedNetwork,
 } from "@/app/stellar-wallet-kit";
 import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
@@ -11,6 +13,7 @@ import { createClient } from "@/lib/supabase/client";
 import { WalletAddress } from "@/components/wallet-address";
 import { ProfileDrawer } from "@/components/profile-drawer";
 import { WalletSelectionModal } from "@/components/wallet-selection-modal";
+import { WalletNetworkWarning } from "@/components/wallet-network-warning";
 import { handleAppError } from "@/lib/error-handler";
 
 export default function ConnectWallet() {
@@ -96,13 +99,31 @@ export default function ConnectWallet() {
     setIsModalOpen(true);
   }
 
+  async function handleWalletConnected(address: string) {
+    const detected = await detectWalletNetwork();
+    const expected = getExpectedNetwork();
+
+    if (detected !== "unknown" && detected !== expected) {
+      const expectedLabel = expected === "testnet" ? "Testnet" : "Mainnet";
+      const walletLabel = detected === "testnet" ? "Testnet" : "Mainnet";
+      handleAppError(
+        new Error(`Wallet is on ${walletLabel}. Please switch to ${expectedLabel} in your wallet extension.`),
+        "NETWORK_MISMATCH"
+      );
+      await disconnect();
+      setPublicKey(null);
+      return;
+    }
+
+    await authenticateWithWallet(address);
+  }
+
   async function handleConnectSuccess() {
     try {
       const key = await getPublicKey();
       if (key) {
-        await authenticateWithWallet(key);
+        await handleWalletConnected(key);
       } else {
-        // Triggered if the wallet kit returns without a key
         handleAppError(new Error("No public key found"), "WALLET_CONNECT");
         setLoading(false);
       }
@@ -175,6 +196,9 @@ export default function ConnectWallet() {
 
   return (
     <div id="connect-wrap" className="wrap" aria-live="polite">
+      {!loading && publicKey && (
+        <WalletNetworkWarning variant="inline" className="mb-2" />
+      )}
       {!loading && publicKey && (
         <ProfileDrawer publicKey={publicKey} onDisconnect={handleDisconnect}>
           <div

--- a/components/wallet-network-warning.tsx
+++ b/components/wallet-network-warning.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import React, { useEffect, useState, useCallback, useRef } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  detectWalletNetwork,
+  getExpectedNetwork,
+  getPublicKey,
+} from "@/app/stellar-wallet-kit";
+import type { DetectedNetwork } from "@/app/stellar-wallet-kit";
+
+interface WalletNetworkWarningProps {
+  variant?: "banner" | "badge" | "inline";
+  className?: string;
+}
+
+export function WalletNetworkWarning({
+  variant = "inline",
+  className,
+}: WalletNetworkWarningProps) {
+  const [walletNetwork, setWalletNetwork] = useState<DetectedNetwork | null>(null);
+  const [expected, setExpected] = useState<DetectedNetwork>("mainnet");
+  const [checking, setChecking] = useState(true);
+  const [isConnected, setIsConnected] = useState(false);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const isMismatch = walletNetwork !== null && walletNetwork !== "unknown" && walletNetwork !== expected;
+
+  const checkNetwork = useCallback(async () => {
+    const pk = await getPublicKey();
+    setIsConnected(!!pk);
+
+    if (!pk) {
+      setWalletNetwork(null);
+      setChecking(false);
+      return;
+    }
+
+    const detected = await detectWalletNetwork();
+    setWalletNetwork(detected);
+    setExpected(getExpectedNetwork());
+    setChecking(false);
+
+    if (detected !== "unknown" && detected === getExpectedNetwork()) {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    checkNetwork();
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+      }
+    };
+  }, [checkNetwork]);
+
+  useEffect(() => {
+    if (isMismatch && !pollingRef.current) {
+      pollingRef.current = setInterval(async () => {
+        const detected = await detectWalletNetwork();
+        setWalletNetwork(detected);
+        if (detected !== "unknown" && detected === getExpectedNetwork()) {
+          if (pollingRef.current) {
+            clearInterval(pollingRef.current);
+            pollingRef.current = null;
+          }
+          window.location.reload();
+        }
+      }, 2000);
+    }
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, [isMismatch]);
+
+  if (checking || !isConnected || walletNetwork === null || walletNetwork === "unknown") {
+    return null;
+  }
+
+  if (!isMismatch) return null;
+
+  const expectedLabel = expected === "testnet" ? "Testnet" : "Mainnet";
+  const walletLabel = walletNetwork === "testnet" ? "Testnet" : "Mainnet";
+
+  if (variant === "badge") {
+    return (
+      <div
+        className={cn(
+          "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium bg-amber-500/10 border-amber-500/20 text-amber-600 dark:text-amber-400",
+          className
+        )}
+        title={`Switch wallet to ${expectedLabel}`}
+      >
+        <AlertTriangle className="w-3 h-3" />
+        <span>Wrong network</span>
+      </div>
+    );
+  }
+
+  if (variant === "inline") {
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-2 px-3 py-2 rounded-lg border text-sm bg-amber-500/10 border-amber-500/20 text-amber-600 dark:text-amber-400",
+          className
+        )}
+      >
+        <AlertTriangle className="w-4 h-4 shrink-0" />
+        <span className="text-xs">
+          Wallet on <strong>{walletLabel}</strong> &middot; switch to <strong>{expectedLabel}</strong>
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "w-full px-4 py-3 border-b bg-amber-500/10 border-amber-500/20",
+        className
+      )}
+    >
+      <div className="max-w-7xl mx-auto flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <AlertTriangle className="w-5 h-5 shrink-0 text-amber-500" />
+          <div>
+            <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+              Wrong Stellar Network Detected
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Your wallet is connected to <strong>{walletLabel}</strong> but this app requires{" "}
+              <strong>{expectedLabel}</strong>. Please switch networks in your wallet extension.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <RefreshCw className="w-3 h-3 animate-spin" />
+            Auto-detecting...
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -3,7 +3,7 @@ import { toast } from "react-hot-toast";
 /**
  * Valid error contexts to ensure consistent categorization across the app.
  */
-export type ErrorContext = "WALLET_CONNECT" | "SEND_MESSAGE" | "NETWORK";
+export type ErrorContext = "WALLET_CONNECT" | "SEND_MESSAGE" | "NETWORK" | "NETWORK_MISMATCH";
 
 /**
  * Global error handler that logs technical details for developers
@@ -27,6 +27,10 @@ export const handleAppError = (error: any, context: ErrorContext) => {
     case "NETWORK":
       userFriendlyMessage =
         "Network error. Please check your internet connection.";
+      break;
+    case "NETWORK_MISMATCH":
+      userFriendlyMessage =
+        "Wrong Stellar network detected. Please switch your wallet to the correct network.";
       break;
   }
 

--- a/lib/stellar/network-detection.ts
+++ b/lib/stellar/network-detection.ts
@@ -1,0 +1,108 @@
+import {
+  FreighterModule,
+  AlbedoModule,
+  WalletNetwork,
+  FREIGHTER_ID,
+  ALBEDO_ID,
+} from "@creit.tech/stellar-wallets-kit";
+import { logBlockchainOperation } from "@/lib/blockchain/logger";
+
+export type DetectedNetwork = "testnet" | "mainnet" | "unknown";
+
+const SELECTED_WALLET_ID_KEY = "selectedWalletId";
+
+function getSelectedWalletId(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(SELECTED_WALLET_ID_KEY);
+}
+
+export function getExpectedNetwork(): DetectedNetwork {
+  if (typeof process !== "undefined" && process.env.NEXT_PUBLIC_STELLAR_NETWORK) {
+    const env = process.env.NEXT_PUBLIC_STELLAR_NETWORK.toLowerCase();
+    if (env === "testnet" || env === "mainnet") {
+      return env;
+    }
+  }
+  return "mainnet";
+}
+
+export function isExpectedNetwork(network: DetectedNetwork): boolean {
+  if (network === "unknown") return false;
+  return network === getExpectedNetwork();
+}
+
+export function networkToPassphrase(network: DetectedNetwork): string {
+  if (network === "testnet") return "Test SDF Network ; September 2015";
+  if (network === "mainnet") return "Public Global Stellar Network ; September 2015";
+  return "";
+}
+
+export async function detectWalletNetwork(): Promise<DetectedNetwork> {
+  if (typeof window === "undefined") return "unknown";
+
+  const walletId = getSelectedWalletId();
+  if (!walletId) return "unknown";
+
+  try {
+    if (walletId === FREIGHTER_ID) {
+      const module = new FreighterModule();
+      const isAvailable = await module.isAvailable();
+      if (!isAvailable) return "unknown";
+      const { network } = await module.getNetwork();
+      return normalizeNetwork(network);
+    }
+
+    if (walletId === ALBEDO_ID) {
+      const module = new AlbedoModule();
+      const isAvailable = await module.isAvailable();
+      if (!isAvailable) return "unknown";
+      const { network } = await module.getNetwork();
+      return normalizeNetwork(network);
+    }
+  } catch (error) {
+    logBlockchainOperation("warn", "Wallet network detection failed", {
+      walletId,
+      error: String(error),
+    });
+  }
+
+  return "unknown";
+}
+
+export async function detectNetworkForWallet(walletId: string): Promise<DetectedNetwork> {
+  if (typeof window === "undefined") return "unknown";
+
+  try {
+    if (walletId === FREIGHTER_ID) {
+      const module = new FreighterModule();
+      const isAvailable = await module.isAvailable();
+      if (!isAvailable) return "unknown";
+      const { network } = await module.getNetwork();
+      return normalizeNetwork(network);
+    }
+
+    if (walletId === ALBEDO_ID) {
+      const module = new AlbedoModule();
+      const isAvailable = await module.isAvailable();
+      if (!isAvailable) return "unknown";
+      const { network } = await module.getNetwork();
+      return normalizeNetwork(network);
+    }
+  } catch (error) {
+    logBlockchainOperation("warn", "Wallet network detection failed", {
+      walletId,
+      error: String(error),
+    });
+  }
+
+  return "unknown";
+}
+
+function normalizeNetwork(network: string): DetectedNetwork {
+  const upper = network.toUpperCase();
+  if (upper === "PUBLIC" || upper === "MAINNET") return "mainnet";
+  if (upper === "TESTNET" || upper === "TEST" || upper === "TEST_NET") return "testnet";
+  if (network.includes("Test SDF Network")) return "testnet";
+  if (network.includes("Public Global")) return "mainnet";
+  return "unknown";
+}


### PR DESCRIPTION
- Detect wallet network via Freighter/Albedo module getNetwork()
- Read NEXT_PUBLIC_STELLAR_NETWORK env var instead of hardcoding mainnet
- Show WalletNetworkWarning banner/inline/badge on network mismatch
- Block wallet authentication on wrong network with user-friendly error
- Block group creation on wrong network with actionable feedback
- Auto-refresh page when user switches to correct network (polls every 2s)
- Add NETWORK_MISMATCH error context for consistent toast messaging
- Both Testnet and Mainnet fully recognized and validated

# 📌 Pull Request

## 🔗 Related Issue

Closes #221

---

## 📝 Description

- What does this PR do?
- Why is this change necessary?

---

## 🚀 Changes Made

- [ ] Feature implemented:
- [ ] Bug fixed:
- [ ] Refactor:
- [ ] Documentation updated:

---

## 🧪 Testing & Validation

- [ ] Tested locally
- [ ] No runtime errors
- [ ] Existing features work as expected
- [ ] Edge cases handled

---

## ⚠️ Breaking Changes

- [ ] No breaking changes
- [ ] Breaking changes exist (explain below)

**If yes, explain:**

- ***

## 📸 Screenshots (REQUIRED for UI changes)

| Before | After |
| ------ | ----- |
|        |       |

---

## 📋 Contributor Checklist (MANDATORY)

- [ ] I was assigned to this issue
- [ ] My code follows the project structure and conventions
- [ ] I have tested my changes thoroughly
- [ ] I did not introduce unnecessary dependencies
- [ ] I have linked the issue (`Closes #`)
- [ ] This PR is ready for review

---

## 💡 Notes for Reviewer

- Key areas to review:
- Known limitations:
