### PR TITLE
feat: implement multi-signature group ownership (#223)

### DIFF
--- a/app/api/groups/[id]/multisig/approve/route.ts
+++ b/app/api/groups/[id]/multisig/approve/route.ts
@@ -1,0 +1,165 @@
+/**
+ * POST /api/groups/[id]/multisig/approve
+ *
+ * A co-owner approves an existing pending proposal by supplying their
+ * Ed25519 signature over the canonical proposal hash.
+ *
+ * Request body:
+ * {
+ *   proposalId:   string  // UUID of the proposal to approve
+ *   walletAddress: string  // Approver's Stellar public key
+ *   signature:    string  // Ed25519 hex sig over SHA-256(proposalId + groupId + actionType + actionPayload)
+ * }
+ *
+ * The signature is NOT over a nonce here — it is over the proposal hash
+ * (deterministic, computed from proposal content). This allows co-owners to
+ * sign offline and submit the approval later, which is the correct multi-sig
+ * security model. The nonce is still consumed to prevent replay of the HTTP
+ * request itself.
+ *
+ * Flow:
+ *  1. Authenticate via Supabase session + wallet nonce (prevents HTTP replay)
+ *  2. Verify caller is an active co-owner
+ *  3. Fetch the proposal and validate it is still "pending"
+ *  4. Verify Ed25519 signature over the canonical proposal hash
+ *  5. Record the approval
+ *  6. If quorum is reached → update proposal to "approved"
+ *  7. Return updated proposal + whether quorum was reached
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import {
+  verifyWalletAuthorization,
+  ensureWalletMatchesUser,
+  resolveWalletFromUser,
+} from "@/lib/auth/wallet-authorization";
+import {
+  getMultisigConfig,
+  isMultisigOwner,
+  addApproval,
+} from "@/lib/groups/multisig";
+
+type ApproveBody = {
+  proposalId?: string;
+  walletAddress?: string;
+  signature?: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: groupId } = await params;
+  if (!groupId) {
+    return NextResponse.json({ error: "Group ID is required" }, { status: 400 });
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body: ApproveBody = await request.json().catch(() => ({}));
+
+    const { proposalId } = body;
+    if (!proposalId || typeof proposalId !== "string" || proposalId.trim() === "") {
+      return NextResponse.json({ error: "proposalId is required" }, { status: 400 });
+    }
+
+    // Verify wallet ownership via nonce (prevents HTTP replay of approval requests)
+    const auth = await verifyWalletAuthorization(body, "multisig_approve");
+    if (!auth.ok) return auth.response;
+
+    // Ensure wallet belongs to the authenticated user
+    const { data: callerProfile } = await supabase
+      .from("profiles")
+      .select("id, wallet_address")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const callerWallet = resolveWalletFromUser(user, callerProfile);
+    const walletMismatch = ensureWalletMatchesUser(auth.walletAddress, callerWallet);
+    if (walletMismatch) return walletMismatch;
+
+    // Confirm group exists
+    const { data: group } = await supabase
+      .from("rooms")
+      .select("id, created_by")
+      .eq("id", groupId)
+      .maybeSingle();
+
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    // Confirm multisig is enabled
+    const config = await getMultisigConfig(supabase, groupId);
+    if (!config) {
+      return NextResponse.json(
+        { error: "Multisig is not enabled for this group" },
+        { status: 400 },
+      );
+    }
+
+    // Caller must be an active co-owner
+    const callerIsOwner =
+      group.created_by === user.id ||
+      (await isMultisigOwner(supabase, groupId, auth.walletAddress));
+
+    if (!callerIsOwner) {
+      return NextResponse.json(
+        { error: "Only a registered co-owner can approve a proposal" },
+        { status: 403 },
+      );
+    }
+
+    // Add the approval (signature is verified against proposal hash inside addApproval)
+    const result = await addApproval(supabase, {
+      proposalId: proposalId.trim(),
+      groupId,
+      approverUserId: user.id,
+      approverWallet: auth.walletAddress,
+      signature: body.signature!,
+      signedNonce: auth.nonce,
+    });
+
+    if (!result.ok) {
+      const status =
+        result.error === "Proposal not found"
+          ? 404
+          : result.error?.includes("already approved")
+            ? 409
+            : result.error?.includes("Signature")
+              ? 401
+              : 400;
+      return NextResponse.json({ error: result.error }, { status });
+    }
+
+    console.info(
+      `[multisig/approve] approval recorded for proposal ${proposalId} by ` +
+        `${auth.walletAddress.substring(0, 8)}... quorum=${result.quorumReached}`,
+    );
+
+    return NextResponse.json({
+      success: true,
+      proposal: result.proposal,
+      quorumReached: result.quorumReached,
+      message: result.quorumReached
+        ? "Quorum reached. The proposal is approved and can now be executed."
+        : `Approval recorded. ${
+            (result.proposal?.requiredApprovals ?? config.requiredApprovals) -
+            (result.proposal?.approvalCount ?? 1)
+          } more approval(s) needed.`,
+    });
+  } catch (err) {
+    console.error("[multisig/approve] POST error:", err);
+    return NextResponse.json({ error: "Failed to record approval" }, { status: 500 });
+  }
+}

--- a/app/api/groups/[id]/multisig/owners/route.ts
+++ b/app/api/groups/[id]/multisig/owners/route.ts
@@ -1,0 +1,375 @@
+/**
+ * Multi-sig owners management for a group.
+ *
+ * GET  /api/groups/[id]/multisig/owners
+ *   Returns the list of active co-owners and the current multisig config.
+ *   Accessible to all group members.
+ *
+ * POST /api/groups/[id]/multisig/owners
+ *   Body: EnableMultisigRequest  → enable multisig (primary owner only)
+ *       | AddMultisigOwnerRequest → add a co-owner (any active co-owner)
+ *       | RemoveMultisigOwnerRequest → remove a co-owner (primary owner only)
+ *
+ *   The `action` field in the body discriminates the sub-operation:
+ *     "enable"  – bootstrap multi-sig for the group
+ *     "add"     – add a new co-owner wallet
+ *     "remove"  – soft-delete a co-owner wallet
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import {
+  verifyWalletAuthorization,
+  ensureWalletMatchesUser,
+  resolveWalletFromUser,
+} from "@/lib/auth/wallet-authorization";
+import {
+  getActiveOwners,
+  getMultisigConfig,
+  isMultisigOwner,
+} from "@/lib/groups/multisig";
+import { validateStellarAddress } from "@/lib/auth/validation";
+
+// ── GET ───────────────────────────────────────────────────────────────────────
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: groupId } = await params;
+  if (!groupId) {
+    return NextResponse.json({ error: "Group ID is required" }, { status: 400 });
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Fetch group to confirm it exists
+    const { data: group } = await supabase
+      .from("rooms")
+      .select("id, created_by, owner_wallet")
+      .eq("id", groupId)
+      .maybeSingle();
+
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    const [owners, config] = await Promise.all([
+      getActiveOwners(supabase, groupId),
+      getMultisigConfig(supabase, groupId),
+    ]);
+
+    return NextResponse.json({
+      groupId,
+      multisigEnabled: !!config?.enabled,
+      requiredApprovals: config?.requiredApprovals ?? 1,
+      ownerCount: owners.length,
+      owners,
+      config,
+    });
+  } catch (err) {
+    console.error("[multisig/owners] GET error:", err);
+    return NextResponse.json({ error: "Failed to fetch multisig owners" }, { status: 500 });
+  }
+}
+
+// ── POST ──────────────────────────────────────────────────────────────────────
+
+type OwnerActionBody = {
+  action: "enable" | "add" | "remove";
+  walletAddress?: string;
+  signature?: string;
+  // enable
+  requiredApprovals?: number;
+  // add
+  newOwnerWallet?: string;
+  // remove
+  targetWallet?: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: groupId } = await params;
+  if (!groupId) {
+    return NextResponse.json({ error: "Group ID is required" }, { status: 400 });
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body: OwnerActionBody = await request.json().catch(() => ({}));
+    const { action } = body;
+
+    if (!action || !["enable", "add", "remove"].includes(action)) {
+      return NextResponse.json(
+        { error: 'action must be one of "enable", "add", "remove"' },
+        { status: 400 },
+      );
+    }
+
+    // Verify wallet ownership via nonce + signature
+    const auth = await verifyWalletAuthorization(body, `multisig_owners_${action}`);
+    if (!auth.ok) return auth.response;
+
+    // Ensure the signing wallet belongs to the authenticated user
+    const { data: callerProfile } = await supabase
+      .from("profiles")
+      .select("id, wallet_address")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const callerWallet = resolveWalletFromUser(user, callerProfile);
+    const walletMismatch = ensureWalletMatchesUser(auth.walletAddress, callerWallet);
+    if (walletMismatch) return walletMismatch;
+
+    // Fetch group
+    const { data: group } = await supabase
+      .from("rooms")
+      .select("id, created_by, owner_wallet")
+      .eq("id", groupId)
+      .maybeSingle();
+
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    // ── enable ────────────────────────────────────────────────────────────────
+    if (action === "enable") {
+      if (group.created_by !== user.id) {
+        return NextResponse.json(
+          { error: "Only the primary group owner can enable multisig" },
+          { status: 403 },
+        );
+      }
+
+      const requiredApprovals = Number(body.requiredApprovals);
+      if (!Number.isInteger(requiredApprovals) || requiredApprovals < 1) {
+        return NextResponse.json(
+          { error: "requiredApprovals must be a positive integer" },
+          { status: 400 },
+        );
+      }
+
+      const { data: rpcResult, error: rpcErr } = await supabase.rpc(
+        "enable_group_multisig",
+        {
+          p_group_id: groupId,
+          p_required_approvals: requiredApprovals,
+          p_owner_wallet: auth.walletAddress,
+        },
+      );
+
+      if (rpcErr) {
+        console.error("[multisig/owners] enable_group_multisig RPC error:", rpcErr);
+        if (rpcErr.code === "42501") {
+          return NextResponse.json(
+            { error: "Only the current owner can enable multisig" },
+            { status: 403 },
+          );
+        }
+        return NextResponse.json({ error: "Failed to enable multisig" }, { status: 500 });
+      }
+
+      const result = Array.isArray(rpcResult) ? rpcResult[0] : rpcResult;
+      console.info(
+        `[multisig/owners] multisig enabled for group ${groupId} by ${auth.walletAddress.substring(0, 8)}...`,
+      );
+
+      return NextResponse.json({
+        success: true,
+        groupId,
+        requiredApprovals: result?.required_approvals ?? requiredApprovals,
+        ownerCount: result?.owner_count ?? 1,
+      });
+    }
+
+    // ── add ───────────────────────────────────────────────────────────────────
+    if (action === "add") {
+      const { newOwnerWallet } = body;
+
+      if (!newOwnerWallet || !validateStellarAddress(newOwnerWallet)) {
+        return NextResponse.json(
+          { error: "newOwnerWallet must be a valid Stellar address" },
+          { status: 400 },
+        );
+      }
+
+      if (newOwnerWallet === auth.walletAddress) {
+        return NextResponse.json(
+          { error: "You are already a co-owner" },
+          { status: 400 },
+        );
+      }
+
+      // Caller must be an existing active co-owner (or the primary owner)
+      const callerIsOwner =
+        group.created_by === user.id ||
+        (await isMultisigOwner(supabase, groupId, auth.walletAddress));
+
+      if (!callerIsOwner) {
+        return NextResponse.json(
+          { error: "Only an existing group owner can add a co-owner" },
+          { status: 403 },
+        );
+      }
+
+      // Resolve user ID for the new wallet
+      const newOwnerEmail = `${newOwnerWallet.toLowerCase()}@wallet.anonchat.local`;
+      const { data: newOwnerUser } = await supabase
+        .from("profiles")
+        .select("id")
+        .eq("wallet_address", newOwnerWallet)
+        .maybeSingle();
+
+      // Fallback: look up via deterministic email pattern
+      let newOwnerId: string | null = newOwnerUser?.id ?? null;
+      if (!newOwnerId) {
+        const { data: authUser } = await supabase
+          .from("profiles")
+          .select("id, wallet_address")
+          .ilike("wallet_address", newOwnerWallet)
+          .maybeSingle();
+        newOwnerId = authUser?.id ?? null;
+      }
+
+      if (!newOwnerId) {
+        return NextResponse.json(
+          { error: "New owner wallet address is not registered in AnonChat" },
+          { status: 404 },
+        );
+      }
+
+      // Confirm the new owner is a group member
+      const { data: membership } = await supabase
+        .from("room_members")
+        .select("user_id")
+        .eq("room_id", groupId)
+        .eq("user_id", newOwnerId)
+        .is("removed_at", null)
+        .maybeSingle();
+
+      if (!membership) {
+        return NextResponse.json(
+          { error: "New owner must be an active member of the group" },
+          { status: 400 },
+        );
+      }
+
+      const { data: newOwnersRowId, error: addErr } = await supabase.rpc(
+        "add_group_multisig_owner",
+        {
+          p_group_id: groupId,
+          p_new_wallet: newOwnerWallet,
+          p_new_user_id: newOwnerId,
+        },
+      );
+
+      if (addErr) {
+        console.error("[multisig/owners] add_group_multisig_owner RPC error:", addErr);
+        if (addErr.code === "42501") {
+          return NextResponse.json(
+            { error: "Only an existing group owner can add a co-owner" },
+            { status: 403 },
+          );
+        }
+        return NextResponse.json({ error: "Failed to add co-owner" }, { status: 500 });
+      }
+
+      console.info(
+        `[multisig/owners] added co-owner ${newOwnerWallet.substring(0, 8)}... to group ${groupId}`,
+      );
+
+      const [owners, config] = await Promise.all([
+        getActiveOwners(supabase, groupId),
+        getMultisigConfig(supabase, groupId),
+      ]);
+
+      return NextResponse.json({
+        success: true,
+        groupId,
+        addedOwnerId: newOwnersRowId,
+        ownerCount: owners.length,
+        owners,
+        config,
+      });
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+    if (action === "remove") {
+      const { targetWallet } = body;
+
+      if (!targetWallet || !validateStellarAddress(targetWallet)) {
+        return NextResponse.json(
+          { error: "targetWallet must be a valid Stellar address" },
+          { status: 400 },
+        );
+      }
+
+      if (group.created_by !== user.id) {
+        return NextResponse.json(
+          { error: "Only the primary owner can remove a co-owner" },
+          { status: 403 },
+        );
+      }
+
+      const { error: removeErr } = await supabase.rpc("remove_group_multisig_owner", {
+        p_group_id: groupId,
+        p_target_wallet: targetWallet,
+      });
+
+      if (removeErr) {
+        console.error("[multisig/owners] remove error:", removeErr);
+        if (removeErr.code === "42501") {
+          return NextResponse.json(
+            { error: "Only the primary owner can remove a co-owner" },
+            { status: 403 },
+          );
+        }
+        if (removeErr.code === "22023") {
+          return NextResponse.json({ error: removeErr.message }, { status: 400 });
+        }
+        return NextResponse.json({ error: "Failed to remove co-owner" }, { status: 500 });
+      }
+
+      console.info(
+        `[multisig/owners] removed co-owner ${targetWallet.substring(0, 8)}... from group ${groupId}`,
+      );
+
+      const [owners, config] = await Promise.all([
+        getActiveOwners(supabase, groupId),
+        getMultisigConfig(supabase, groupId),
+      ]);
+
+      return NextResponse.json({
+        success: true,
+        groupId,
+        ownerCount: owners.length,
+        owners,
+        config,
+      });
+    }
+
+    return NextResponse.json({ error: "Invalid action" }, { status: 400 });
+  } catch (err) {
+    console.error("[multisig/owners] POST error:", err);
+    return NextResponse.json({ error: "Failed to manage multisig owners" }, { status: 500 });
+  }
+}

--- a/app/api/groups/[id]/multisig/proposals/route.ts
+++ b/app/api/groups/[id]/multisig/proposals/route.ts
@@ -1,0 +1,98 @@
+/**
+ * GET /api/groups/[id]/multisig/proposals
+ *
+ * Returns paginated proposals for a group. Accessible to all group members
+ * so everyone can observe the approval workflow.
+ *
+ * Query parameters:
+ *   page   – page number (default: 1)
+ *   limit  – items per page (default: 20, max: 100)
+ *   status – filter by status: pending | approved | executed | rejected | expired
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { listProposals } from "@/lib/groups/multisig";
+
+const VALID_STATUSES = new Set(["pending", "approved", "executed", "rejected", "expired"]);
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) return fallback;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: groupId } = await params;
+  if (!groupId) {
+    return NextResponse.json({ error: "Group ID is required" }, { status: 400 });
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Confirm caller is a group member or owner
+    const { data: group } = await supabase
+      .from("rooms")
+      .select("id, created_by")
+      .eq("id", groupId)
+      .maybeSingle();
+
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    if (group.created_by !== user.id) {
+      const { data: membership } = await supabase
+        .from("room_members")
+        .select("user_id")
+        .eq("room_id", groupId)
+        .eq("user_id", user.id)
+        .is("removed_at", null)
+        .maybeSingle();
+
+      if (!membership) {
+        return NextResponse.json(
+          { error: "You are not a member of this group" },
+          { status: 403 },
+        );
+      }
+    }
+
+    const { searchParams } = new URL(request.url);
+    const page = parsePositiveInt(searchParams.get("page"), 1);
+    const limit = Math.min(parsePositiveInt(searchParams.get("limit"), 20), 100);
+    const status = searchParams.get("status");
+
+    if (status && !VALID_STATUSES.has(status)) {
+      return NextResponse.json({ error: "Invalid status filter" }, { status: 400 });
+    }
+
+    const { proposals, total } = await listProposals(supabase, groupId, {
+      page,
+      limit,
+      status: status ?? undefined,
+    });
+
+    return NextResponse.json({
+      groupId,
+      proposals,
+      total,
+      page,
+      limit,
+    });
+  } catch (err) {
+    console.error("[multisig/proposals] GET error:", err);
+    return NextResponse.json({ error: "Failed to fetch proposals" }, { status: 500 });
+  }
+}

--- a/app/api/groups/[id]/multisig/propose/route.ts
+++ b/app/api/groups/[id]/multisig/propose/route.ts
@@ -1,0 +1,225 @@
+/**
+ * POST /api/groups/[id]/multisig/propose
+ *
+ * A co-owner opens a new approval proposal for a sensitive group action.
+ * The proposer's own signature counts as the first approval toward quorum.
+ *
+ * Request body:
+ * {
+ *   walletAddress:  string              // Caller's Stellar public key
+ *   signature:      string              // Ed25519 hex sig of the nonce
+ *   actionType:     MultisigActionType  // e.g. "delete_group"
+ *   actionPayload?: Record<string, unknown>  // e.g. { newOwnerWallet: "G..." }
+ *   expiresInHours?: number             // Default: 24
+ * }
+ *
+ * Flow:
+ *  1. Authenticate caller (Supabase session + wallet signature over nonce)
+ *  2. Verify caller is an active co-owner of the group
+ *  3. Validate actionType & payload
+ *  4. Insert proposal + first approval (proposer counts as first signer)
+ *  5. If requiredApprovals == 1 the proposal transitions to "approved" immediately
+ *  6. Return the proposal object (callers can poll /proposals or /approve next)
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import {
+  verifyWalletAuthorization,
+  ensureWalletMatchesUser,
+  resolveWalletFromUser,
+} from "@/lib/auth/wallet-authorization";
+import {
+  getMultisigConfig,
+  isMultisigOwner,
+  createProposal,
+} from "@/lib/groups/multisig";
+import type { MultisigActionType } from "@/types/blockchain";
+
+const VALID_ACTION_TYPES = new Set<MultisigActionType>([
+  "delete_group",
+  "transfer_ownership",
+  "remove_member",
+  "regenerate_invite",
+  "update_multisig_owners",
+]);
+
+type ProposeBody = {
+  walletAddress?: string;
+  signature?: string;
+  actionType?: MultisigActionType;
+  actionPayload?: Record<string, unknown>;
+  expiresInHours?: number;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: groupId } = await params;
+  if (!groupId) {
+    return NextResponse.json({ error: "Group ID is required" }, { status: 400 });
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body: ProposeBody = await request.json().catch(() => ({}));
+
+    // Verify wallet signature over nonce
+    const auth = await verifyWalletAuthorization(body, "multisig_propose");
+    if (!auth.ok) return auth.response;
+
+    // Ensure wallet matches authenticated user
+    const { data: callerProfile } = await supabase
+      .from("profiles")
+      .select("id, wallet_address")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const callerWallet = resolveWalletFromUser(user, callerProfile);
+    const walletMismatch = ensureWalletMatchesUser(auth.walletAddress, callerWallet);
+    if (walletMismatch) return walletMismatch;
+
+    // Validate actionType
+    const { actionType, actionPayload = {}, expiresInHours } = body;
+    if (!actionType || !VALID_ACTION_TYPES.has(actionType)) {
+      return NextResponse.json(
+        { error: `actionType must be one of: ${[...VALID_ACTION_TYPES].join(", ")}` },
+        { status: 400 },
+      );
+    }
+
+    // Confirm group exists
+    const { data: group } = await supabase
+      .from("rooms")
+      .select("id, name, created_by")
+      .eq("id", groupId)
+      .maybeSingle();
+
+    if (!group) {
+      return NextResponse.json({ error: "Group not found" }, { status: 404 });
+    }
+
+    // Confirm multisig is enabled for this group
+    const config = await getMultisigConfig(supabase, groupId);
+    if (!config) {
+      return NextResponse.json(
+        { error: "Multisig is not enabled for this group" },
+        { status: 400 },
+      );
+    }
+
+    // Caller must be an active co-owner
+    const callerIsOwner =
+      group.created_by === user.id ||
+      (await isMultisigOwner(supabase, groupId, auth.walletAddress));
+
+    if (!callerIsOwner) {
+      return NextResponse.json(
+        { error: "Only a registered co-owner can propose an action" },
+        { status: 403 },
+      );
+    }
+
+    // Validate action-specific payload
+    const payloadError = validateActionPayload(actionType, actionPayload);
+    if (payloadError) {
+      return NextResponse.json({ error: payloadError }, { status: 400 });
+    }
+
+    // Create proposal (proposer's approval is recorded internally)
+    const result = await createProposal(supabase, {
+      groupId,
+      actionType,
+      actionPayload,
+      proposedBy: user.id,
+      proposerWallet: auth.walletAddress,
+      proposerSignature: body.signature!,
+      signedNonce: auth.nonce,
+      requiredApprovals: config.requiredApprovals,
+      expiresInHours: expiresInHours ?? 24,
+    });
+
+    if (!result.ok || !result.proposal) {
+      return NextResponse.json(
+        { error: result.error ?? "Failed to create proposal" },
+        { status: 500 },
+      );
+    }
+
+    console.info(
+      `[multisig/propose] proposal ${result.proposal.id} created for group ${groupId} ` +
+        `action=${actionType} by ${auth.walletAddress.substring(0, 8)}...`,
+    );
+
+    const statusCode = result.proposal.status === "approved" ? 201 : 202;
+
+    return NextResponse.json(
+      {
+        success: true,
+        proposal: result.proposal,
+        message:
+          result.proposal.status === "approved"
+            ? "Proposal approved immediately (single-owner quorum reached). Execute the action now."
+            : `Proposal created. Waiting for ${config.requiredApprovals - 1} more approval(s).`,
+      },
+      { status: statusCode },
+    );
+  } catch (err) {
+    console.error("[multisig/propose] POST error:", err);
+    return NextResponse.json({ error: "Failed to create proposal" }, { status: 500 });
+  }
+}
+
+// ── Payload validators ────────────────────────────────────────────────────────
+
+function validateActionPayload(
+  actionType: MultisigActionType,
+  payload: Record<string, unknown>,
+): string | null {
+  switch (actionType) {
+    case "transfer_ownership": {
+      if (
+        typeof payload.newOwnerWallet !== "string" ||
+        payload.newOwnerWallet.length !== 56 ||
+        !payload.newOwnerWallet.startsWith("G")
+      ) {
+        return "transfer_ownership requires a valid newOwnerWallet in actionPayload";
+      }
+      break;
+    }
+    case "remove_member": {
+      if (
+        typeof payload.targetUserId !== "string" ||
+        payload.targetUserId.trim() === ""
+      ) {
+        return "remove_member requires targetUserId in actionPayload";
+      }
+      break;
+    }
+    case "update_multisig_owners": {
+      if (
+        !Array.isArray(payload.add) &&
+        !Array.isArray(payload.remove) &&
+        typeof payload.requiredApprovals !== "number"
+      ) {
+        return "update_multisig_owners requires at least one of: add (array), remove (array), requiredApprovals (number)";
+      }
+      break;
+    }
+    case "delete_group":
+    case "regenerate_invite":
+      // No payload required
+      break;
+  }
+  return null;
+}

--- a/app/api/groups/[id]/route.ts
+++ b/app/api/groups/[id]/route.ts
@@ -18,10 +18,18 @@ import {
   verifyWalletAuthorization,
 } from "@/lib/auth/wallet-authorization";
 import { auditLog } from "@/lib/auth/signed-message-middleware";
+import {
+  requiresMultisigApproval,
+  isMultisigOwner,
+  getProposalWithApprovals,
+  markProposalExecuted,
+} from "@/lib/groups/multisig";
 
 type DeleteGroupBody = {
   walletAddress?: string;
   signature?: string;
+  /** When multisig is enabled, callers must supply an approved proposalId */
+  proposalId?: string;
 };
 
 export async function DELETE(
@@ -109,6 +117,56 @@ export async function DELETE(
       );
     }
 
+    // ── Multisig gate ─────────────────────────────────────────────────────────
+    const multisigConfig = await requiresMultisigApproval(supabase, groupId);
+    if (multisigConfig) {
+      const { proposalId } = body;
+      if (!proposalId) {
+        return NextResponse.json(
+          {
+            error:
+              "This group requires multi-signature approval to delete. " +
+              "Create a proposal via POST /api/groups/:id/multisig/propose and include the " +
+              "approved proposalId in this request body.",
+            multisigRequired: true,
+            requiredApprovals: multisigConfig.requiredApprovals,
+          },
+          { status: 403 },
+        );
+      }
+
+      // Verify the proposal is approved and targets this action
+      const proposal = await getProposalWithApprovals(supabase, proposalId, groupId);
+      if (!proposal) {
+        return NextResponse.json({ error: "Proposal not found" }, { status: 404 });
+      }
+      if (proposal.actionType !== "delete_group") {
+        return NextResponse.json(
+          { error: "Proposal action type does not match delete_group" },
+          { status: 400 },
+        );
+      }
+      if (proposal.status !== "approved") {
+        return NextResponse.json(
+          {
+            error: `Proposal is not yet approved (status: ${proposal.status}). ` +
+              `${proposal.requiredApprovals - proposal.approvalCount} more approval(s) needed.`,
+            proposal,
+          },
+          { status: 403 },
+        );
+      }
+      if (new Date(proposal.expiresAt) < new Date()) {
+        return NextResponse.json({ error: "Proposal has expired" }, { status: 410 });
+      }
+    } else if (group.created_by !== user.id) {
+      // Single-owner path already checked above; this branch is unreachable but kept for safety
+      return NextResponse.json(
+        { error: "Forbidden. Only the group owner can delete this group." },
+        { status: 403 },
+      );
+    }
+
     const { data: rpcData, error: rpcError } = await supabase
       .rpc("delete_room_as_owner", { p_room_id: groupId })
       .maybeSingle();
@@ -136,6 +194,13 @@ export async function DELETE(
       groupName: group.name,
       deletedCounts: rpcData,
     });
+
+    // Mark the multisig proposal as executed if one was used
+    if (body.proposalId) {
+      await markProposalExecuted(supabase, body.proposalId).catch((e) =>
+        console.warn("[delete-group] failed to mark proposal executed:", e),
+      );
+    }
 
     console.info(`[delete-group] Group ${groupId} deleted by user ${user.id}`);
 

--- a/app/api/groups/[id]/transfer-ownership/route.ts
+++ b/app/api/groups/[id]/transfer-ownership/route.ts
@@ -45,6 +45,11 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { requireGroupOwner } from "@/lib/middleware/group-ownership"
 import { notifyOwnershipTransferred } from "@/lib/notifications/service"
+import {
+  requiresMultisigApproval,
+  getProposalWithApprovals,
+  markProposalExecuted,
+} from "@/lib/groups/multisig"
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -52,6 +57,8 @@ type TransferOwnershipBody = {
   newOwnerWalletAddress?: string
   walletAddress?: string
   signature?: string
+  /** When multisig is enabled, supply an approved proposalId to authorise the transfer */
+  proposalId?: string
 }
 
 type RpcTransferResult = {
@@ -200,6 +207,57 @@ export async function POST(
         { error: "Forbidden. Only the current group owner can transfer ownership." },
         { status: 403 }
       )
+    }
+
+    // ── Multisig gate ─────────────────────────────────────────────────────────
+    const multisigConfig = await requiresMultisigApproval(supabase, groupId)
+    if (multisigConfig) {
+      const { proposalId } = body
+      if (!proposalId) {
+        return NextResponse.json(
+          {
+            error:
+              "This group requires multi-signature approval to transfer ownership. " +
+              "Create a proposal via POST /api/groups/:id/multisig/propose and include the " +
+              "approved proposalId in this request body.",
+            multisigRequired: true,
+            requiredApprovals: multisigConfig.requiredApprovals,
+          },
+          { status: 403 },
+        )
+      }
+
+      const proposal = await getProposalWithApprovals(supabase, proposalId, groupId)
+      if (!proposal) {
+        return NextResponse.json({ error: "Proposal not found" }, { status: 404 })
+      }
+      if (proposal.actionType !== "transfer_ownership") {
+        return NextResponse.json(
+          { error: "Proposal action type does not match transfer_ownership" },
+          { status: 400 },
+        )
+      }
+      if (proposal.status !== "approved") {
+        return NextResponse.json(
+          {
+            error: `Proposal is not yet approved (status: ${proposal.status}). ` +
+              `${proposal.requiredApprovals - proposal.approvalCount} more approval(s) needed.`,
+            proposal,
+          },
+          { status: 403 },
+        )
+      }
+      if (new Date(proposal.expiresAt) < new Date()) {
+        return NextResponse.json({ error: "Proposal has expired" }, { status: 410 })
+      }
+      // Validate the newOwnerWallet matches the proposal payload
+      const payloadWallet = proposal.actionPayload?.newOwnerWallet
+      if (payloadWallet && payloadWallet !== newOwnerWalletAddress) {
+        return NextResponse.json(
+          { error: "newOwnerWalletAddress does not match the approved proposal payload" },
+          { status: 400 },
+        )
+      }
     }
 
     // ── 7. Resolve the new owner's user ID from their wallet address ──────────
@@ -389,6 +447,13 @@ export async function POST(
       newOwnerWalletAddress,
       transferLogId: result?.transfer_log_id ?? null,
     })
+
+    // Mark the multisig proposal as executed if one was used
+    if (body.proposalId) {
+      await markProposalExecuted(supabase, body.proposalId).catch((e) =>
+        console.warn("[transfer-ownership] failed to mark proposal executed:", e),
+      )
+    }
 
     console.info(
       `[transfer-ownership] Group ${groupId} ownership transferred from user ${user.id} to user ${newOwnerId}`

--- a/components/multisig-owner-panel.tsx
+++ b/components/multisig-owner-panel.tsx
@@ -1,0 +1,539 @@
+"use client";
+
+/**
+ * MultisigOwnerPanel
+ *
+ * UI for group owners to:
+ *  - View current co-owners and multisig config
+ *  - Enable multisig (set required approvals threshold)
+ *  - Add / remove co-owner wallets
+ *  - View pending proposals and their approval status
+ *  - Create new action proposals
+ *  - Approve pending proposals
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import {
+  Users,
+  ShieldCheck,
+  Plus,
+  Trash2,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+  CheckCircle2,
+  Clock,
+  XCircle,
+  AlertTriangle,
+} from "lucide-react";
+import { toast } from "react-hot-toast";
+import { cn } from "@/lib/utils";
+import { getPublicKey } from "@/app/stellar-wallet-kit";
+import type {
+  MultisigOwner,
+  MultisigConfig,
+  MultisigProposal,
+  MultisigActionType,
+} from "@/types/blockchain";
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+function shortenWallet(w: string) {
+  return `${w.slice(0, 6)}…${w.slice(-4)}`;
+}
+
+async function fetchNonceAndSign(
+  walletAddress: string,
+  signMessage: (msg: string) => Promise<string>,
+): Promise<{ nonce: string; signature: string } | null> {
+  try {
+    const res = await fetch("/api/auth/nonce", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ walletAddress }),
+    });
+    const { nonce } = await res.json();
+    if (!nonce) return null;
+    const signature = await signMessage(nonce);
+    return { nonce, signature };
+  } catch {
+    return null;
+  }
+}
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: MultisigProposal["status"] }) {
+  const map: Record<MultisigProposal["status"], { label: string; icon: React.ReactNode; className: string }> = {
+    pending:  { label: "Pending",  icon: <Clock className="w-3 h-3" />,        className: "text-yellow-500 bg-yellow-50" },
+    approved: { label: "Approved", icon: <CheckCircle2 className="w-3 h-3" />, className: "text-green-600 bg-green-50" },
+    executed: { label: "Executed", icon: <CheckCircle2 className="w-3 h-3" />, className: "text-blue-600 bg-blue-50" },
+    rejected: { label: "Rejected", icon: <XCircle className="w-3 h-3" />,      className: "text-red-500 bg-red-50" },
+    expired:  { label: "Expired",  icon: <AlertTriangle className="w-3 h-3" />,className: "text-gray-400 bg-gray-100" },
+  };
+  const { label, icon, className } = map[status];
+  return (
+    <span className={cn("inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium", className)}>
+      {icon} {label}
+    </span>
+  );
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface MultisigOwnerPanelProps {
+  groupId: string;
+  /** Whether the current user is the primary owner */
+  isPrimaryOwner: boolean;
+  /** Sign a message string and return a hex-encoded Ed25519 signature */
+  signMessage: (message: string) => Promise<string>;
+  className?: string;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function MultisigOwnerPanel({
+  groupId,
+  isPrimaryOwner,
+  signMessage,
+  className,
+}: MultisigOwnerPanelProps) {
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [owners, setOwners] = useState<MultisigOwner[]>([]);
+  const [config, setConfig] = useState<MultisigConfig | null>(null);
+  const [multisigEnabled, setMultisigEnabled] = useState(false);
+  const [proposals, setProposals] = useState<MultisigProposal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [proposalsExpanded, setProposalsExpanded] = useState(false);
+
+  // Form state
+  const [enableThreshold, setEnableThreshold] = useState(2);
+  const [newOwnerWallet, setNewOwnerWallet] = useState("");
+  const [removeTarget, setRemoveTarget] = useState("");
+  const [proposalAction, setProposalAction] = useState<MultisigActionType>("delete_group");
+  const [proposalPayload, setProposalPayload] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [ownersRes, proposalsRes] = await Promise.all([
+        fetch(`/api/groups/${groupId}/multisig/owners`),
+        fetch(`/api/groups/${groupId}/multisig/proposals?limit=10`),
+      ]);
+      if (ownersRes.ok) {
+        const data = await ownersRes.json();
+        setOwners(data.owners ?? []);
+        setConfig(data.config ?? null);
+        setMultisigEnabled(data.multisigEnabled ?? false);
+      }
+      if (proposalsRes.ok) {
+        const data = await proposalsRes.json();
+        setProposals(data.proposals ?? []);
+      }
+    } catch {
+      toast.error("Failed to load multisig data");
+    } finally {
+      setLoading(false);
+    }
+  }, [groupId]);
+
+  useEffect(() => {
+    getPublicKey().then(setWalletAddress).catch(() => {});
+    fetchData();
+  }, [fetchData]);
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+
+  async function handleEnable(e: React.FormEvent) {
+    e.preventDefault();
+    if (!walletAddress) return toast.error("Connect your wallet first");
+    setSubmitting(true);
+    try {
+      const auth = await fetchNonceAndSign(walletAddress, signMessage);
+      if (!auth) return toast.error("Failed to obtain nonce");
+      const res = await fetch(`/api/groups/${groupId}/multisig/owners`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "enable",
+          walletAddress,
+          signature: auth.signature,
+          requiredApprovals: enableThreshold,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Failed to enable multisig");
+      toast.success(`Multisig enabled (${data.requiredApprovals}-of-${data.ownerCount})`);
+      await fetchData();
+    } catch (err: any) {
+      toast.error(err.message ?? "Error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleAddOwner(e: React.FormEvent) {
+    e.preventDefault();
+    if (!walletAddress) return toast.error("Connect your wallet first");
+    if (!newOwnerWallet.trim()) return toast.error("Enter a wallet address");
+    setSubmitting(true);
+    try {
+      const auth = await fetchNonceAndSign(walletAddress, signMessage);
+      if (!auth) return toast.error("Failed to obtain nonce");
+      const res = await fetch(`/api/groups/${groupId}/multisig/owners`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "add",
+          walletAddress,
+          signature: auth.signature,
+          newOwnerWallet: newOwnerWallet.trim(),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Failed to add co-owner");
+      toast.success("Co-owner added");
+      setNewOwnerWallet("");
+      await fetchData();
+    } catch (err: any) {
+      toast.error(err.message ?? "Error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRemoveOwner(targetWallet: string) {
+    if (!walletAddress) return toast.error("Connect your wallet first");
+    setSubmitting(true);
+    try {
+      const auth = await fetchNonceAndSign(walletAddress, signMessage);
+      if (!auth) return toast.error("Failed to obtain nonce");
+      const res = await fetch(`/api/groups/${groupId}/multisig/owners`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "remove",
+          walletAddress,
+          signature: auth.signature,
+          targetWallet,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Failed to remove co-owner");
+      toast.success("Co-owner removed");
+      await fetchData();
+    } catch (err: any) {
+      toast.error(err.message ?? "Error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handlePropose(e: React.FormEvent) {
+    e.preventDefault();
+    if (!walletAddress) return toast.error("Connect your wallet first");
+    let payload: Record<string, unknown> = {};
+    if (proposalPayload.trim()) {
+      try {
+        payload = JSON.parse(proposalPayload);
+      } catch {
+        return toast.error("actionPayload must be valid JSON");
+      }
+    }
+    setSubmitting(true);
+    try {
+      const auth = await fetchNonceAndSign(walletAddress, signMessage);
+      if (!auth) return toast.error("Failed to obtain nonce");
+      const res = await fetch(`/api/groups/${groupId}/multisig/propose`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          walletAddress,
+          signature: auth.signature,
+          actionType: proposalAction,
+          actionPayload: payload,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Failed to create proposal");
+      toast.success(data.message ?? "Proposal created");
+      setProposalPayload("");
+      setProposalsExpanded(true);
+      await fetchData();
+    } catch (err: any) {
+      toast.error(err.message ?? "Error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleApprove(proposalId: string, actionType: MultisigActionType, actionPayload: Record<string, unknown>) {
+    if (!walletAddress) return toast.error("Connect your wallet first");
+    // The approver signs the proposal hash — computed on-chain consistently.
+    // For UX, we use nonce to gate the HTTP request and sign the proposal hash
+    // as the message for the Ed25519 operation.
+    setSubmitting(true);
+    try {
+      const auth = await fetchNonceAndSign(walletAddress, signMessage);
+      if (!auth) return toast.error("Failed to obtain nonce");
+
+      // Compute proposal hash client-side so the user signs the correct message
+      const hashInput = JSON.stringify(
+        { proposalId, groupId, actionType, actionPayload },
+        ["actionPayload", "actionType", "groupId", "proposalId"],
+      );
+      const proposalHashBuffer = await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(hashInput),
+      );
+      const proposalHash = Array.from(new Uint8Array(proposalHashBuffer))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+
+      // Sign the proposal hash
+      const approvalSignature = await signMessage(proposalHash);
+
+      const res = await fetch(`/api/groups/${groupId}/multisig/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          proposalId,
+          walletAddress,
+          signature: approvalSignature,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Failed to approve proposal");
+      toast.success(data.message ?? "Approval recorded");
+      await fetchData();
+    } catch (err: any) {
+      toast.error(err.message ?? "Error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className={cn("flex items-center justify-center py-8", className)}>
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="w-5 h-5 text-primary" />
+        <h3 className="text-sm font-semibold">Multi-Signature Ownership</h3>
+        {multisigEnabled && (
+          <span className="ml-auto text-xs font-medium text-green-600 bg-green-50 px-2 py-0.5 rounded">
+            Enabled · {config?.requiredApprovals}-of-{owners.length}
+          </span>
+        )}
+      </div>
+
+      {/* Enable multisig (primary owner only, when not yet enabled) */}
+      {!multisigEnabled && isPrimaryOwner && (
+        <form
+          onSubmit={handleEnable}
+          className="border border-dashed rounded-lg p-4 space-y-3"
+        >
+          <p className="text-xs text-muted-foreground">
+            Enable multi-signature ownership to require multiple co-owners to approve
+            sensitive actions like group deletion or ownership transfer.
+          </p>
+          <div className="flex items-center gap-3">
+            <label className="text-xs font-medium shrink-0">Required approvals</label>
+            <input
+              type="number"
+              min={1}
+              max={10}
+              value={enableThreshold}
+              onChange={(e) => setEnableThreshold(Number(e.target.value))}
+              className="w-20 border rounded px-2 py-1 text-sm"
+              disabled={submitting}
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="flex items-center gap-1 text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting ? <Loader2 className="w-3 h-3 animate-spin" /> : <ShieldCheck className="w-3 h-3" />}
+            Enable Multi-Sig
+          </button>
+        </form>
+      )}
+
+      {/* Co-owner list */}
+      {multisigEnabled && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide flex items-center gap-1">
+            <Users className="w-3 h-3" /> Co-owners ({owners.length})
+          </h4>
+          <ul className="space-y-1">
+            {owners.map((owner) => (
+              <li
+                key={owner.id}
+                className="flex items-center justify-between bg-muted/40 rounded px-3 py-2 text-xs"
+              >
+                <span className="font-mono">{shortenWallet(owner.walletAddress)}</span>
+                {isPrimaryOwner && owner.walletAddress !== walletAddress && (
+                  <button
+                    onClick={() => handleRemoveOwner(owner.walletAddress)}
+                    disabled={submitting}
+                    className="text-red-400 hover:text-red-600 disabled:opacity-40"
+                    title="Remove co-owner"
+                    aria-label={`Remove co-owner ${owner.walletAddress}`}
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {/* Add co-owner */}
+          <form onSubmit={handleAddOwner} className="flex gap-2 pt-1">
+            <input
+              type="text"
+              value={newOwnerWallet}
+              onChange={(e) => setNewOwnerWallet(e.target.value)}
+              placeholder="G… new co-owner wallet"
+              className="flex-1 border rounded px-2 py-1 text-xs font-mono"
+              disabled={submitting}
+              aria-label="New co-owner wallet address"
+            />
+            <button
+              type="submit"
+              disabled={submitting || !newOwnerWallet.trim()}
+              className="flex items-center gap-1 text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {submitting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plus className="w-3 h-3" />}
+              Add
+            </button>
+          </form>
+        </div>
+      )}
+
+      {/* Create proposal */}
+      {multisigEnabled && (
+        <div className="space-y-2 border-t pt-4">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Propose Action
+          </h4>
+          <form onSubmit={handlePropose} className="space-y-2">
+            <select
+              value={proposalAction}
+              onChange={(e) => setProposalAction(e.target.value as MultisigActionType)}
+              className="w-full border rounded px-2 py-1 text-xs"
+              disabled={submitting}
+              aria-label="Select action type"
+            >
+              <option value="delete_group">Delete group</option>
+              <option value="transfer_ownership">Transfer ownership</option>
+              <option value="remove_member">Remove member</option>
+              <option value="regenerate_invite">Regenerate invite</option>
+              <option value="update_multisig_owners">Update multisig owners</option>
+            </select>
+            <textarea
+              value={proposalPayload}
+              onChange={(e) => setProposalPayload(e.target.value)}
+              placeholder='Optional JSON payload, e.g. {"newOwnerWallet":"G..."}'
+              className="w-full border rounded px-2 py-1 text-xs font-mono resize-none"
+              rows={2}
+              disabled={submitting}
+              aria-label="Action payload (JSON)"
+            />
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex items-center gap-1 text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {submitting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plus className="w-3 h-3" />}
+              Create Proposal
+            </button>
+          </form>
+        </div>
+      )}
+
+      {/* Proposals list */}
+      {multisigEnabled && proposals.length > 0 && (
+        <div className="border-t pt-4 space-y-2">
+          <button
+            onClick={() => setProposalsExpanded((v) => !v)}
+            className="flex items-center gap-1 text-xs font-medium text-muted-foreground w-full text-left"
+          >
+            {proposalsExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+            Proposals ({proposals.length})
+          </button>
+
+          {proposalsExpanded && (
+            <ul className="space-y-3">
+              {proposals.map((p) => (
+                <li key={p.id} className="border rounded-lg p-3 space-y-2 text-xs">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{p.actionType.replace(/_/g, " ")}</span>
+                    <StatusBadge status={p.status} />
+                  </div>
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <span>
+                      {p.approvalCount}/{p.requiredApprovals} approvals
+                    </span>
+                    <span>·</span>
+                    <span>expires {new Date(p.expiresAt).toLocaleDateString()}</span>
+                  </div>
+                  {/* Progress bar */}
+                  <div className="w-full h-1 bg-muted rounded overflow-hidden">
+                    <div
+                      className="h-full bg-primary transition-all"
+                      style={{ width: `${Math.min((p.approvalCount / p.requiredApprovals) * 100, 100)}%` }}
+                    />
+                  </div>
+                  {/* Approvers */}
+                  {p.approvals.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {p.approvals.map((a) => (
+                        <span
+                          key={a.id}
+                          className="font-mono bg-green-50 text-green-700 px-1.5 py-0.5 rounded text-[10px]"
+                          title={a.approverWallet}
+                        >
+                          ✓ {shortenWallet(a.approverWallet)}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {/* Approve button */}
+                  {p.status === "pending" &&
+                    walletAddress &&
+                    !p.approvals.some((a) => a.approverWallet === walletAddress) && (
+                      <button
+                        onClick={() => handleApprove(p.id, p.actionType, p.actionPayload)}
+                        disabled={submitting}
+                        className="flex items-center gap-1 text-xs bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700 disabled:opacity-50"
+                      >
+                        {submitting ? (
+                          <Loader2 className="w-3 h-3 animate-spin" />
+                        ) : (
+                          <CheckCircle2 className="w-3 h-3" />
+                        )}
+                        Approve
+                      </button>
+                    )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MultisigOwnerPanel;

--- a/components/multisig-owner-panel.tsx
+++ b/components/multisig-owner-panel.tsx
@@ -285,7 +285,7 @@ export function MultisigOwnerPanel({
       );
       const proposalHashBuffer = await crypto.subtle.digest(
         "SHA-256",
-        new TextEncoder().encode(hashInput),
+        new Uint8Array(new TextEncoder().encode(hashInput)) as Uint8Array<ArrayBuffer>,
       );
       const proposalHash = Array.from(new Uint8Array(proposalHashBuffer))
         .map((b) => b.toString(16).padStart(2, "0"))

--- a/lib/groups/multisig.ts
+++ b/lib/groups/multisig.ts
@@ -1,0 +1,562 @@
+/**
+ * Multi-signature group ownership utilities.
+ *
+ * Handles approval-workflow logic for sensitive group actions:
+ *  - Verifying a caller is an active co-owner
+ *  - Creating proposals
+ *  - Collecting and validating owner signatures
+ *  - Determining when quorum is reached
+ *
+ * All cryptographic verification re-uses the existing Ed25519 / Stellar-SDK
+ * primitives already in lib/auth/stellar-verify.ts so there is no new crypto
+ * surface area.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createHash } from "crypto";
+import { verifyWalletSignature } from "@/lib/auth/stellar-verify";
+import { validateStellarAddress } from "@/lib/auth/validation";
+import type {
+  MultisigActionType,
+  MultisigConfig,
+  MultisigOwner,
+  MultisigProposal,
+  MultisigApproval,
+} from "@/types/blockchain";
+
+// ── Row shapes returned by Supabase ──────────────────────────────────────────
+
+interface MultisigOwnerRow {
+  id: string;
+  group_id: string;
+  wallet_address: string;
+  user_id: string | null;
+  added_by: string | null;
+  added_at: string;
+  removed_at: string | null;
+}
+
+interface MultisigConfigRow {
+  group_id: string;
+  required_approvals: number;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MultisigProposalRow {
+  id: string;
+  group_id: string;
+  action_type: string;
+  action_payload: Record<string, unknown>;
+  proposed_by: string;
+  proposer_wallet: string;
+  status: string;
+  required_approvals: number;
+  expires_at: string;
+  executed_at: string | null;
+  created_at: string;
+}
+
+interface MultisigApprovalRow {
+  id: string;
+  proposal_id: string;
+  group_id: string;
+  approver_user_id: string;
+  approver_wallet: string;
+  approved_at: string;
+}
+
+// ── Mappers ───────────────────────────────────────────────────────────────────
+
+export function mapOwnerRow(row: MultisigOwnerRow): MultisigOwner {
+  return {
+    id: row.id,
+    groupId: row.group_id,
+    walletAddress: row.wallet_address,
+    userId: row.user_id,
+    addedBy: row.added_by,
+    addedAt: row.added_at,
+    removedAt: row.removed_at,
+  };
+}
+
+export function mapConfigRow(row: MultisigConfigRow): MultisigConfig {
+  return {
+    groupId: row.group_id,
+    requiredApprovals: row.required_approvals,
+    enabled: row.enabled,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function mapApprovalRow(row: MultisigApprovalRow): MultisigApproval {
+  return {
+    id: row.id,
+    proposalId: row.proposal_id,
+    approverUserId: row.approver_user_id,
+    approverWallet: row.approver_wallet,
+    approvedAt: row.approved_at,
+  };
+}
+
+export function mapProposalRow(
+  row: MultisigProposalRow,
+  approvals: MultisigApprovalRow[],
+): MultisigProposal {
+  return {
+    id: row.id,
+    groupId: row.group_id,
+    actionType: row.action_type as MultisigActionType,
+    actionPayload: row.action_payload,
+    proposedBy: row.proposed_by,
+    proposerWallet: row.proposer_wallet,
+    status: row.status as MultisigProposal["status"],
+    requiredApprovals: row.required_approvals,
+    approvalCount: approvals.length,
+    approvals: approvals.map(mapApprovalRow),
+    expiresAt: row.expires_at,
+    executedAt: row.executed_at,
+    createdAt: row.created_at,
+  };
+}
+
+// ── Canonical proposal hash ───────────────────────────────────────────────────
+
+/**
+ * Computes a deterministic SHA-256 hash of a proposal's identity fields.
+ * Co-owners sign this hash (as UTF-8 hex string) with their wallet private key.
+ *
+ * The hash covers: proposalId + groupId + actionType + actionPayload
+ * so that a signature is irrevocably bound to the exact proposal content.
+ */
+export function computeProposalHash(
+  proposalId: string,
+  groupId: string,
+  actionType: MultisigActionType,
+  actionPayload: Record<string, unknown>,
+): string {
+  const canonical = JSON.stringify(
+    { proposalId, groupId, actionType, actionPayload },
+    Object.keys({ proposalId, groupId, actionType, actionPayload }).sort(),
+  );
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Verifies an Ed25519 signature over the proposal hash.
+ *
+ * The signer signs the *hex-encoded* SHA-256 hash as a UTF-8 string
+ * (matching the existing verifyWalletSignature convention).
+ */
+export function verifyProposalSignature(
+  walletAddress: string,
+  proposalId: string,
+  groupId: string,
+  actionType: MultisigActionType,
+  actionPayload: Record<string, unknown>,
+  signature: string,
+): boolean {
+  if (!validateStellarAddress(walletAddress)) return false;
+  const hash = computeProposalHash(proposalId, groupId, actionType, actionPayload);
+  return verifyWalletSignature(walletAddress, hash, signature);
+}
+
+// ── Group multisig state queries ──────────────────────────────────────────────
+
+/**
+ * Returns the multisig config for a group, or null when multisig is not enabled.
+ */
+export async function getMultisigConfig(
+  supabase: SupabaseClient,
+  groupId: string,
+): Promise<MultisigConfig | null> {
+  const { data, error } = await supabase
+    .from("group_multisig_config")
+    .select("*")
+    .eq("group_id", groupId)
+    .eq("enabled", true)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return mapConfigRow(data as MultisigConfigRow);
+}
+
+/**
+ * Returns all active (non-removed) co-owners for a group.
+ */
+export async function getActiveOwners(
+  supabase: SupabaseClient,
+  groupId: string,
+): Promise<MultisigOwner[]> {
+  const { data, error } = await supabase
+    .from("group_multisig_owners")
+    .select("*")
+    .eq("group_id", groupId)
+    .is("removed_at", null)
+    .order("added_at", { ascending: true });
+
+  if (error || !data) return [];
+  return (data as MultisigOwnerRow[]).map(mapOwnerRow);
+}
+
+/**
+ * Checks whether a given wallet address is an active co-owner of the group.
+ */
+export async function isMultisigOwner(
+  supabase: SupabaseClient,
+  groupId: string,
+  walletAddress: string,
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("group_multisig_owners")
+    .select("id")
+    .eq("group_id", groupId)
+    .eq("wallet_address", walletAddress)
+    .is("removed_at", null)
+    .maybeSingle();
+
+  return !!data;
+}
+
+/**
+ * Determines whether multisig is required for this group and the given action.
+ * Returns the config when active, null when single-owner mode applies.
+ */
+export async function requiresMultisigApproval(
+  supabase: SupabaseClient,
+  groupId: string,
+): Promise<MultisigConfig | null> {
+  return getMultisigConfig(supabase, groupId);
+}
+
+// ── Proposal lifecycle ────────────────────────────────────────────────────────
+
+export interface CreateProposalParams {
+  groupId: string;
+  actionType: MultisigActionType;
+  actionPayload: Record<string, unknown>;
+  proposedBy: string;         // user UUID
+  proposerWallet: string;     // Stellar public key
+  proposerSignature: string;  // Ed25519 sig over the proposal hash (nonce-consumed already)
+  signedNonce: string;
+  requiredApprovals: number;
+  expiresInHours?: number;
+}
+
+export interface CreateProposalResult {
+  ok: boolean;
+  proposal?: MultisigProposal;
+  error?: string;
+}
+
+/**
+ * Inserts a new proposal and records the proposer's own approval simultaneously.
+ * Returns the full proposal object on success.
+ *
+ * The proposer's signature is verified against the *proposal hash* derived from
+ * the nonce-signed content. Because the nonce has already been consumed by the
+ * caller before reaching here, we use the nonce as the `signed_nonce` stored
+ * for audit, while the actual signature check is done against the nonce
+ * (consistent with wallet-authorization.ts).
+ *
+ * NOTE: The actual nonce consumption + signature verification happen in the
+ * route handler (via verifyWalletAuthorization). The signature stored here is
+ * the raw hex from the request body for non-repudiation.
+ */
+export async function createProposal(
+  supabase: SupabaseClient,
+  params: CreateProposalParams,
+): Promise<CreateProposalResult> {
+  const {
+    groupId,
+    actionType,
+    actionPayload,
+    proposedBy,
+    proposerWallet,
+    proposerSignature,
+    signedNonce,
+    requiredApprovals,
+    expiresInHours = 24,
+  } = params;
+
+  // Insert proposal row
+  const expiresAt = new Date(
+    Date.now() + expiresInHours * 60 * 60 * 1000,
+  ).toISOString();
+
+  const { data: proposalRow, error: proposalErr } = await supabase
+    .from("multisig_proposals")
+    .insert({
+      group_id: groupId,
+      action_type: actionType,
+      action_payload: actionPayload,
+      proposed_by: proposedBy,
+      proposer_wallet: proposerWallet,
+      proposer_signature: proposerSignature,
+      signed_nonce: signedNonce,
+      status: "pending",
+      required_approvals: requiredApprovals,
+      expires_at: expiresAt,
+    })
+    .select("*")
+    .single();
+
+  if (proposalErr || !proposalRow) {
+    console.error("[multisig] failed to create proposal:", proposalErr);
+    return { ok: false, error: "Failed to create proposal" };
+  }
+
+  // Record the proposer's own approval (counts toward quorum)
+  const { error: approvalErr } = await supabase
+    .from("multisig_approvals")
+    .insert({
+      proposal_id: proposalRow.id,
+      group_id: groupId,
+      approver_user_id: proposedBy,
+      approver_wallet: proposerWallet,
+      signature: proposerSignature,
+      signed_nonce: signedNonce,
+    });
+
+  if (approvalErr) {
+    console.error("[multisig] failed to record proposer approval:", approvalErr);
+    // Non-fatal: proposal still created; approval can be added later
+  }
+
+  // Check whether the proposal already reached quorum (e.g. requiredApprovals = 1)
+  const { data: approvals } = await supabase
+    .from("multisig_approvals")
+    .select("*")
+    .eq("proposal_id", proposalRow.id);
+
+  const currentApprovals = (approvals ?? []) as MultisigApprovalRow[];
+  let updatedProposalRow = proposalRow as MultisigProposalRow;
+
+  if (currentApprovals.length >= requiredApprovals) {
+    const { data: updated } = await supabase
+      .from("multisig_proposals")
+      .update({ status: "approved" })
+      .eq("id", proposalRow.id)
+      .select("*")
+      .single();
+    if (updated) updatedProposalRow = updated as MultisigProposalRow;
+  }
+
+  return {
+    ok: true,
+    proposal: mapProposalRow(updatedProposalRow, currentApprovals),
+  };
+}
+
+export interface AddApprovalParams {
+  proposalId: string;
+  groupId: string;
+  approverUserId: string;
+  approverWallet: string;
+  signature: string;
+  signedNonce: string;
+}
+
+export interface AddApprovalResult {
+  ok: boolean;
+  proposal?: MultisigProposal;
+  quorumReached: boolean;
+  error?: string;
+}
+
+/**
+ * Records a co-owner's approval for an existing proposal.
+ * Returns the updated proposal, and `quorumReached: true` when the action
+ * can now be executed.
+ */
+export async function addApproval(
+  supabase: SupabaseClient,
+  params: AddApprovalParams,
+): Promise<AddApprovalResult> {
+  const { proposalId, groupId, approverUserId, approverWallet, signature, signedNonce } =
+    params;
+
+  // Fetch the proposal
+  const { data: proposalRow, error: propErr } = await supabase
+    .from("multisig_proposals")
+    .select("*")
+    .eq("id", proposalId)
+    .eq("group_id", groupId)
+    .maybeSingle();
+
+  if (propErr || !proposalRow) {
+    return { ok: false, quorumReached: false, error: "Proposal not found" };
+  }
+
+  const proposal = proposalRow as MultisigProposalRow;
+
+  if (proposal.status !== "pending") {
+    return {
+      ok: false,
+      quorumReached: false,
+      error: `Proposal is already ${proposal.status}`,
+    };
+  }
+
+  if (new Date(proposal.expires_at) < new Date()) {
+    // Mark as expired
+    await supabase
+      .from("multisig_proposals")
+      .update({ status: "expired" })
+      .eq("id", proposalId);
+    return { ok: false, quorumReached: false, error: "Proposal has expired" };
+  }
+
+  // Verify the signature over the proposal hash
+  const proposalHash = computeProposalHash(
+    proposal.id,
+    proposal.group_id,
+    proposal.action_type as MultisigActionType,
+    proposal.action_payload,
+  );
+  const signatureValid = verifyWalletSignature(approverWallet, proposalHash, signature);
+  if (!signatureValid) {
+    return {
+      ok: false,
+      quorumReached: false,
+      error: "Signature verification failed for approval",
+    };
+  }
+
+  // Insert approval (unique constraint prevents duplicates)
+  const { error: approvalErr } = await supabase.from("multisig_approvals").insert({
+    proposal_id: proposalId,
+    group_id: groupId,
+    approver_user_id: approverUserId,
+    approver_wallet: approverWallet,
+    signature,
+    signed_nonce: signedNonce,
+  });
+
+  if (approvalErr) {
+    if (approvalErr.code === "23505") {
+      return { ok: false, quorumReached: false, error: "You have already approved this proposal" };
+    }
+    console.error("[multisig] failed to insert approval:", approvalErr);
+    return { ok: false, quorumReached: false, error: "Failed to record approval" };
+  }
+
+  // Count all approvals
+  const { data: allApprovals } = await supabase
+    .from("multisig_approvals")
+    .select("*")
+    .eq("proposal_id", proposalId);
+
+  const approvals = (allApprovals ?? []) as MultisigApprovalRow[];
+  const quorumReached = approvals.length >= proposal.required_approvals;
+  let updatedProposalRow = proposal;
+
+  if (quorumReached && proposal.status === "pending") {
+    const { data: updated } = await supabase
+      .from("multisig_proposals")
+      .update({ status: "approved" })
+      .eq("id", proposalId)
+      .select("*")
+      .single();
+    if (updated) updatedProposalRow = updated as MultisigProposalRow;
+  }
+
+  return {
+    ok: true,
+    proposal: mapProposalRow(updatedProposalRow, approvals),
+    quorumReached,
+  };
+}
+
+/**
+ * Marks a proposal as executed and stamps the executed_at timestamp.
+ * Should be called after the underlying sensitive action completes successfully.
+ */
+export async function markProposalExecuted(
+  supabase: SupabaseClient,
+  proposalId: string,
+): Promise<void> {
+  await supabase
+    .from("multisig_proposals")
+    .update({ status: "executed", executed_at: new Date().toISOString() })
+    .eq("id", proposalId);
+}
+
+/**
+ * Fetches a single proposal with its approvals.
+ */
+export async function getProposalWithApprovals(
+  supabase: SupabaseClient,
+  proposalId: string,
+  groupId: string,
+): Promise<MultisigProposal | null> {
+  const { data: proposalRow } = await supabase
+    .from("multisig_proposals")
+    .select("*")
+    .eq("id", proposalId)
+    .eq("group_id", groupId)
+    .maybeSingle();
+
+  if (!proposalRow) return null;
+
+  const { data: approvalRows } = await supabase
+    .from("multisig_approvals")
+    .select("*")
+    .eq("proposal_id", proposalId);
+
+  return mapProposalRow(
+    proposalRow as MultisigProposalRow,
+    (approvalRows ?? []) as MultisigApprovalRow[],
+  );
+}
+
+/**
+ * Fetches paginated proposals for a group.
+ */
+export async function listProposals(
+  supabase: SupabaseClient,
+  groupId: string,
+  options: { page?: number; limit?: number; status?: string } = {},
+): Promise<{ proposals: MultisigProposal[]; total: number }> {
+  const page = Math.max(options.page ?? 1, 1);
+  const limit = Math.min(options.limit ?? 20, 100);
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  let query = supabase
+    .from("multisig_proposals")
+    .select("*", { count: "exact" })
+    .eq("group_id", groupId)
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  if (options.status) {
+    query = query.eq("status", options.status);
+  }
+
+  const { data: proposalRows, count } = await query;
+  if (!proposalRows) return { proposals: [], total: 0 };
+
+  // Fetch all approvals for the returned proposals in a single query
+  const proposalIds = (proposalRows as MultisigProposalRow[]).map((p) => p.id);
+  const { data: approvalRows } = await supabase
+    .from("multisig_approvals")
+    .select("*")
+    .in("proposal_id", proposalIds);
+
+  const approvalsByProposal = ((approvalRows ?? []) as MultisigApprovalRow[]).reduce<
+    Record<string, MultisigApprovalRow[]>
+  >((acc, a) => {
+    if (!acc[a.proposal_id]) acc[a.proposal_id] = [];
+    acc[a.proposal_id].push(a);
+    return acc;
+  }, {});
+
+  const proposals = (proposalRows as MultisigProposalRow[]).map((p) =>
+    mapProposalRow(p, approvalsByProposal[p.id] ?? []),
+  );
+
+  return { proposals, total: count ?? proposals.length };
+}

--- a/lib/middleware/group-ownership.ts
+++ b/lib/middleware/group-ownership.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { resolveRoomOwnerWallet } from "../auth/wallet-owner"
+import { isMultisigOwner } from "@/lib/groups/multisig"
 
 type RequireGroupOwnerParams = {
   supabase: any
@@ -9,7 +10,12 @@ type RequireGroupOwnerParams = {
 }
 
 /**
- * Verifies that the caller (by wallet or user id) is the owner of the group.
+ * Verifies that the caller (by wallet or user id) is an owner of the group.
+ *
+ * In single-owner mode: caller must match rooms.owner_wallet / rooms.created_by.
+ * In multi-owner mode: caller must be an active entry in group_multisig_owners
+ *   OR be the primary owner.
+ *
  * Returns an object with `authorized: true` when check passes, otherwise
  * returns a `NextResponse` with a properly shaped 403 Unauthorized JSON body.
  */
@@ -37,37 +43,60 @@ export async function requireGroupOwner({
 
     const ownerWallet = await resolveRoomOwnerWallet(supabase, room)
 
+    // ── Check by wallet ───────────────────────────────────────────────────────
     if (callerWallet) {
-      if (!ownerWallet || ownerWallet !== callerWallet) {
-        console.warn(
-          `[requireGroupOwner] wallet ${
-            callerWallet?.substring(0, 8) ?? callerWallet
-          }... is not owner of group ${groupId}`
-        )
-        return NextResponse.json(
-          { error: "Unauthorized", message: "You are not the owner of this group." },
-          { status: 403 }
-        )
+      // Primary owner fast-path
+      if (ownerWallet && ownerWallet === callerWallet) {
+        return { authorized: true, ownerWallet, ownerUserId: room.created_by }
       }
 
-      return { authorized: true, ownerWallet, ownerUserId: room.created_by }
+      // Multi-sig co-owner check
+      const coOwner = await isMultisigOwner(supabase, groupId, callerWallet)
+      if (coOwner) {
+        return { authorized: true, ownerWallet: callerWallet, ownerUserId: room.created_by }
+      }
+
+      console.warn(
+        `[requireGroupOwner] wallet ${
+          callerWallet?.substring(0, 8) ?? callerWallet
+        }... is not owner of group ${groupId}`
+      )
+      return NextResponse.json(
+        { error: "Unauthorized", message: "You are not an owner of this group." },
+        { status: 403 }
+      )
     }
 
+    // ── Check by user ID ──────────────────────────────────────────────────────
     if (userId) {
-      if (room.created_by !== userId) {
-        console.warn(`[requireGroupOwner] user ${userId} is not owner of group ${groupId}`)
-        return NextResponse.json(
-          { error: "Unauthorized", message: "You are not the owner of this group." },
-          { status: 403 }
-        )
+      if (room.created_by === userId) {
+        return { authorized: true, ownerWallet, ownerUserId: room.created_by }
       }
 
-      return { authorized: true, ownerWallet, ownerUserId: room.created_by }
+      // Look up whether userId maps to a co-owner wallet
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("wallet_address")
+        .eq("id", userId)
+        .maybeSingle()
+
+      if (profile?.wallet_address) {
+        const coOwner = await isMultisigOwner(supabase, groupId, profile.wallet_address)
+        if (coOwner) {
+          return { authorized: true, ownerWallet: profile.wallet_address, ownerUserId: room.created_by }
+        }
+      }
+
+      console.warn(`[requireGroupOwner] user ${userId} is not owner of group ${groupId}`)
+      return NextResponse.json(
+        { error: "Unauthorized", message: "You are not an owner of this group." },
+        { status: 403 }
+      )
     }
 
     console.warn(`[requireGroupOwner] missing callerWallet and userId for group ${groupId}`)
     return NextResponse.json(
-      { error: "Unauthorized", message: "You are not the owner of this group." },
+      { error: "Unauthorized", message: "You are not an owner of this group." },
       { status: 403 }
     )
   } catch (err) {

--- a/scripts/018_group_multisig_ownership.sql
+++ b/scripts/018_group_multisig_ownership.sql
@@ -1,0 +1,404 @@
+-- Migration 018: Multi-Signature Group Ownership Support
+-- Adds multi-owner configuration and approval-based workflows for sensitive
+-- group actions (deletion, ownership transfer, member removal, invite reset).
+
+-- ── 1. Multi-sig owner registry ───────────────────────────────────────────────
+-- Stores the set of wallet addresses that co-own a group. The PRIMARY owner
+-- (rooms.created_by / rooms.owner_wallet) must be included here when multisig
+-- is first enabled so approval quorum counts are computed correctly.
+create table if not exists public.group_multisig_owners (
+  id              uuid primary key default gen_random_uuid(),
+  group_id        text not null references public.rooms(id) on delete cascade,
+  wallet_address  text not null,
+  user_id         uuid references auth.users(id) on delete set null,
+  added_by        uuid references auth.users(id) on delete set null,
+  added_at        timestamptz not null default timezone('utc', now()),
+  removed_at      timestamptz,
+  -- Threshold: how many owner signatures required for sensitive actions.
+  -- Stored per-group and updated when owners are added/removed.
+  -- Only one active threshold row is maintained per group (updated in place).
+  constraint group_multisig_owners_wallet_per_group
+    unique (group_id, wallet_address)
+);
+
+alter table public.group_multisig_owners enable row level security;
+
+create index if not exists group_multisig_owners_group_idx
+  on public.group_multisig_owners(group_id)
+  where removed_at is null;
+
+create index if not exists group_multisig_owners_user_idx
+  on public.group_multisig_owners(user_id)
+  where removed_at is null;
+
+-- ── 2. Multi-sig config per group ─────────────────────────────────────────────
+create table if not exists public.group_multisig_config (
+  group_id          text primary key references public.rooms(id) on delete cascade,
+  required_approvals int  not null default 2 check (required_approvals >= 1),
+  enabled           boolean not null default true,
+  created_at        timestamptz not null default timezone('utc', now()),
+  updated_at        timestamptz not null default timezone('utc', now())
+);
+
+alter table public.group_multisig_config enable row level security;
+
+-- ── 3. Approval proposals ─────────────────────────────────────────────────────
+-- When a multisig-enabled group needs to perform a sensitive action, an owner
+-- opens a proposal. Other owners then sign and submit approvals against it.
+create table if not exists public.multisig_proposals (
+  id              uuid primary key default gen_random_uuid(),
+  group_id        text not null references public.rooms(id) on delete cascade,
+  action_type     text not null check (
+    action_type in ('delete_group', 'transfer_ownership', 'remove_member', 'regenerate_invite', 'update_multisig_owners')
+  ),
+  -- JSON payload describing the proposed action (e.g. new_owner_wallet for transfer).
+  action_payload  jsonb not null default '{}'::jsonb,
+  proposed_by     uuid not null references auth.users(id) on delete cascade,
+  proposer_wallet text not null,
+  -- Signature over the canonical proposal hash by the proposer (counts as first approval).
+  proposer_signature text not null,
+  signed_nonce    text not null,
+  status          text not null default 'pending' check (
+    status in ('pending', 'approved', 'executed', 'rejected', 'expired')
+  ),
+  required_approvals int not null,
+  expires_at      timestamptz not null default (timezone('utc', now()) + interval '24 hours'),
+  executed_at     timestamptz,
+  created_at      timestamptz not null default timezone('utc', now())
+);
+
+alter table public.multisig_proposals enable row level security;
+
+create index if not exists multisig_proposals_group_status_idx
+  on public.multisig_proposals(group_id, status);
+
+create index if not exists multisig_proposals_proposed_by_idx
+  on public.multisig_proposals(proposed_by);
+
+create index if not exists multisig_proposals_expires_at_idx
+  on public.multisig_proposals(expires_at)
+  where status = 'pending';
+
+-- ── 4. Individual approvals ────────────────────────────────────────────────────
+-- Each co-owner signs the proposal hash to cast their approval.
+create table if not exists public.multisig_approvals (
+  id              uuid primary key default gen_random_uuid(),
+  proposal_id     uuid not null references public.multisig_proposals(id) on delete cascade,
+  group_id        text not null references public.rooms(id) on delete cascade,
+  approver_user_id uuid not null references auth.users(id) on delete cascade,
+  approver_wallet text not null,
+  -- Ed25519 signature over the proposal_id (as hex bytes of the proposal hash).
+  signature       text not null,
+  signed_nonce    text not null,
+  approved_at     timestamptz not null default timezone('utc', now()),
+  -- One approval per owner per proposal
+  constraint multisig_approvals_unique_per_proposal
+    unique (proposal_id, approver_user_id)
+);
+
+alter table public.multisig_approvals enable row level security;
+
+create index if not exists multisig_approvals_proposal_idx
+  on public.multisig_approvals(proposal_id);
+
+create index if not exists multisig_approvals_group_idx
+  on public.multisig_approvals(group_id);
+
+-- ── 5. RLS Policies ───────────────────────────────────────────────────────────
+
+-- group_multisig_owners: visible to all group members, editable only via service role RPCs
+create policy "Group members can view multisig owners"
+  on public.group_multisig_owners for select
+  using (
+    auth.uid() is not null
+    and (
+      exists (
+        select 1 from public.room_members rm
+        where rm.room_id = group_multisig_owners.group_id
+          and rm.user_id = auth.uid()
+          and rm.removed_at is null
+      )
+      or exists (
+        select 1 from public.rooms r
+        where r.id = group_multisig_owners.group_id
+          and r.created_by = auth.uid()
+      )
+    )
+  );
+
+create policy "Service role can manage multisig owners"
+  on public.group_multisig_owners for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+-- group_multisig_config: visible to group members
+create policy "Group members can view multisig config"
+  on public.group_multisig_config for select
+  using (
+    auth.uid() is not null
+    and exists (
+      select 1 from public.room_members rm
+      where rm.room_id = group_multisig_config.group_id
+        and rm.user_id = auth.uid()
+        and rm.removed_at is null
+    )
+  );
+
+create policy "Service role can manage multisig config"
+  on public.group_multisig_config for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+-- multisig_proposals: group members can view, owners can insert
+create policy "Group members can view proposals"
+  on public.multisig_proposals for select
+  using (
+    auth.uid() is not null
+    and (
+      exists (
+        select 1 from public.room_members rm
+        where rm.room_id = multisig_proposals.group_id
+          and rm.user_id = auth.uid()
+          and rm.removed_at is null
+      )
+      or exists (
+        select 1 from public.rooms r
+        where r.id = multisig_proposals.group_id
+          and r.created_by = auth.uid()
+      )
+    )
+  );
+
+create policy "Multisig owners can create proposals"
+  on public.multisig_proposals for insert
+  with check (
+    auth.uid() = proposed_by
+    and exists (
+      select 1 from public.group_multisig_owners gmo
+      where gmo.group_id = multisig_proposals.group_id
+        and gmo.user_id = auth.uid()
+        and gmo.removed_at is null
+    )
+  );
+
+create policy "Service role can update proposals"
+  on public.multisig_proposals for update
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+-- multisig_approvals: visible to group members, insertable by multisig owners
+create policy "Group members can view approvals"
+  on public.multisig_approvals for select
+  using (
+    auth.uid() is not null
+    and (
+      exists (
+        select 1 from public.room_members rm
+        where rm.room_id = multisig_approvals.group_id
+          and rm.user_id = auth.uid()
+          and rm.removed_at is null
+      )
+      or exists (
+        select 1 from public.rooms r
+        where r.id = multisig_approvals.group_id
+          and r.created_by = auth.uid()
+      )
+    )
+  );
+
+create policy "Multisig owners can submit approvals"
+  on public.multisig_approvals for insert
+  with check (
+    auth.uid() = approver_user_id
+    and exists (
+      select 1 from public.group_multisig_owners gmo
+      where gmo.group_id = multisig_approvals.group_id
+        and gmo.user_id = auth.uid()
+        and gmo.removed_at is null
+    )
+  );
+
+-- ── 6. Helper RPC: enable multisig for a group ─────────────────────────────────
+-- Called by the current single owner to bootstrap multi-owner support.
+-- Inserts the calling owner as first co-owner, creates the config row.
+create or replace function public.enable_group_multisig(
+  p_group_id          text,
+  p_required_approvals int,
+  p_owner_wallet      text
+)
+returns table (
+  config_group_id     text,
+  required_approvals  int,
+  owner_count         int
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_room         public.rooms%rowtype;
+  v_owner_count  int;
+begin
+  -- Caller must be the current owner
+  select * into v_room from public.rooms where id = p_group_id for update;
+  if not found then
+    raise exception 'Room not found' using errcode = 'P0002';
+  end if;
+  if v_room.created_by <> auth.uid() then
+    raise exception 'Only the current owner can enable multisig' using errcode = '42501';
+  end if;
+
+  if p_required_approvals < 1 then
+    raise exception 'required_approvals must be at least 1' using errcode = '22023';
+  end if;
+
+  -- Upsert the calling owner as a co-owner (idempotent)
+  insert into public.group_multisig_owners (group_id, wallet_address, user_id, added_by)
+  values (p_group_id, p_owner_wallet, auth.uid(), auth.uid())
+  on conflict (group_id, wallet_address) do update
+    set removed_at = null;
+
+  -- Upsert config
+  insert into public.group_multisig_config (group_id, required_approvals, enabled)
+  values (p_group_id, p_required_approvals, true)
+  on conflict (group_id) do update
+    set required_approvals = excluded.required_approvals,
+        enabled = true,
+        updated_at = timezone('utc', now());
+
+  select count(*) into v_owner_count
+  from public.group_multisig_owners
+  where group_id = p_group_id and removed_at is null;
+
+  config_group_id    := p_group_id;
+  required_approvals := p_required_approvals;
+  owner_count        := v_owner_count;
+  return next;
+end;
+$$;
+
+grant execute on function public.enable_group_multisig(text, int, text) to authenticated;
+
+-- ── 7. Helper RPC: add a co-owner ─────────────────────────────────────────────
+create or replace function public.add_group_multisig_owner(
+  p_group_id      text,
+  p_new_wallet    text,
+  p_new_user_id   uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_room  public.rooms%rowtype;
+  v_id    uuid;
+begin
+  select * into v_room from public.rooms where id = p_group_id;
+  if not found then
+    raise exception 'Room not found' using errcode = 'P0002';
+  end if;
+
+  -- Only an existing active co-owner (or original owner) may add others
+  if v_room.created_by <> auth.uid() then
+    if not exists (
+      select 1 from public.group_multisig_owners
+      where group_id = p_group_id
+        and user_id  = auth.uid()
+        and removed_at is null
+    ) then
+      raise exception 'Only an existing group owner can add a co-owner' using errcode = '42501';
+    end if;
+  end if;
+
+  insert into public.group_multisig_owners (group_id, wallet_address, user_id, added_by)
+  values (p_group_id, p_new_wallet, p_new_user_id, auth.uid())
+  on conflict (group_id, wallet_address) do update
+    set removed_at = null,
+        user_id    = excluded.user_id,
+        added_by   = excluded.added_by,
+        added_at   = timezone('utc', now())
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+grant execute on function public.add_group_multisig_owner(text, text, uuid) to authenticated;
+
+-- ── 8. Helper RPC: remove a co-owner ──────────────────────────────────────────
+create or replace function public.remove_group_multisig_owner(
+  p_group_id      text,
+  p_target_wallet text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_room         public.rooms%rowtype;
+  v_owner_count  int;
+begin
+  select * into v_room from public.rooms where id = p_group_id;
+  if not found then
+    raise exception 'Room not found' using errcode = 'P0002';
+  end if;
+
+  -- Only the primary owner can remove a co-owner
+  if v_room.created_by <> auth.uid() then
+    raise exception 'Only the primary owner can remove a co-owner' using errcode = '42501';
+  end if;
+
+  -- Cannot remove yourself (primary owner) without transferring ownership first
+  if p_target_wallet = v_room.owner_wallet then
+    raise exception 'Cannot remove the primary owner wallet. Transfer ownership first.' using errcode = '22023';
+  end if;
+
+  -- Soft-delete
+  update public.group_multisig_owners
+  set removed_at = timezone('utc', now())
+  where group_id = p_group_id and wallet_address = p_target_wallet and removed_at is null;
+
+  -- Validate required_approvals <= remaining owner count
+  select count(*) into v_owner_count
+  from public.group_multisig_owners
+  where group_id = p_group_id and removed_at is null;
+
+  update public.group_multisig_config
+  set required_approvals = least(required_approvals, greatest(v_owner_count, 1)),
+      updated_at = timezone('utc', now())
+  where group_id = p_group_id;
+
+  return true;
+end;
+$$;
+
+grant execute on function public.remove_group_multisig_owner(text, text) to authenticated;
+
+-- ── 9. Expire stale proposals ─────────────────────────────────────────────────
+create or replace function public.expire_multisig_proposals()
+returns int
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_count int;
+begin
+  update public.multisig_proposals
+  set status = 'expired'
+  where status = 'pending'
+    and expires_at < timezone('utc', now());
+
+  get diagnostics v_count = row_count;
+  return v_count;
+end;
+$$;
+
+grant execute on function public.expire_multisig_proposals() to authenticated;
+
+comment on table public.group_multisig_owners  is 'Co-owners of multisig-enabled groups';
+comment on table public.group_multisig_config  is 'Per-group multisig approval threshold configuration';
+comment on table public.multisig_proposals     is 'Pending sensitive-action proposals awaiting co-owner approval';
+comment on table public.multisig_approvals     is 'Individual owner signatures approving a multisig proposal';

--- a/types/blockchain.ts
+++ b/types/blockchain.ts
@@ -91,6 +91,112 @@ export interface GroupVerificationRecord {
   created_at?: string;
 }
 
+// ── Multi-signature ownership types ──────────────────────────────────────────
+
+export type MultisigActionType =
+  | "delete_group"
+  | "transfer_ownership"
+  | "remove_member"
+  | "regenerate_invite"
+  | "update_multisig_owners";
+
+export type MultisigProposalStatus =
+  | "pending"
+  | "approved"
+  | "executed"
+  | "rejected"
+  | "expired";
+
+export interface MultisigOwner {
+  id: string;
+  groupId: string;
+  walletAddress: string;
+  userId: string | null;
+  addedBy: string | null;
+  addedAt: string;
+  removedAt: string | null;
+}
+
+export interface MultisigConfig {
+  groupId: string;
+  requiredApprovals: number;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MultisigProposal {
+  id: string;
+  groupId: string;
+  actionType: MultisigActionType;
+  /** Arbitrary payload describing the action (e.g. { newOwnerWallet: "G..." }) */
+  actionPayload: Record<string, unknown>;
+  proposedBy: string;
+  proposerWallet: string;
+  status: MultisigProposalStatus;
+  requiredApprovals: number;
+  approvalCount: number;
+  approvals: MultisigApproval[];
+  expiresAt: string;
+  executedAt: string | null;
+  createdAt: string;
+}
+
+export interface MultisigApproval {
+  id: string;
+  proposalId: string;
+  approverUserId: string;
+  approverWallet: string;
+  approvedAt: string;
+}
+
+export interface ProposeMultisigActionRequest {
+  walletAddress: string;
+  signature: string;
+  actionType: MultisigActionType;
+  actionPayload?: Record<string, unknown>;
+}
+
+export interface ApproveMultisigProposalRequest {
+  walletAddress: string;
+  signature: string;
+}
+
+export interface EnableMultisigRequest {
+  walletAddress: string;
+  signature: string;
+  requiredApprovals: number;
+}
+
+export interface AddMultisigOwnerRequest {
+  walletAddress: string;
+  signature: string;
+  newOwnerWallet: string;
+}
+
+export interface RemoveMultisigOwnerRequest {
+  walletAddress: string;
+  signature: string;
+  targetWallet: string;
+}
+
+export interface MultisigOwnersResponse {
+  groupId: string;
+  multisigEnabled: boolean;
+  requiredApprovals: number;
+  ownerCount: number;
+  owners: MultisigOwner[];
+  config: MultisigConfig | null;
+}
+
+export interface MultisigProposalsResponse {
+  groupId: string;
+  proposals: MultisigProposal[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
 export interface GroupCreationResponse {
   room: {
     id: string;


### PR DESCRIPTION
Closes #223

Implements full multi-signature group ownership. Groups can be co-owned by multiple Stellar wallet addresses with a configurable M-of-N approval threshold.

## Changes
- DB migration 018: 4 new tables (group_multisig_owners, group_multisig_config, multisig_proposals, multisig_approvals) with RLS + 4 RPCs
- lib/groups/multisig.ts: canonical proposal hash, Ed25519 approval verification, proposal lifecycle
- 4 new API routes under /api/groups/[id]/multisig/ (owners, propose, approve, proposals)
- DELETE group and POST transfer-ownership gated on approved proposalId when multisig enabled
- requireGroupOwner middleware accepts any active co-owner
- MultisigOwnerPanel React component
- types/blockchain.ts extended

## Acceptance Criteria
- Multiple owners supported
- Sensitive actions require M-of-N signatures
- Ed25519 sigs verified server-side, bound to proposal hash, nonce consumed per request