### PR TITLE
feat(api): implement chat export api with JSON/TXT streaming and auth enforcement (closes #220)

### DIFF
--- a/app/api/groups/[id]/export/route.ts
+++ b/app/api/groups/[id]/export/route.ts
@@ -1,0 +1,166 @@
+import { createClient } from "@/lib/supabase/server";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: groupId } = await params;
+
+  if (!groupId) {
+    return NextResponse.json({ error: "Group ID is required" }, { status: 400 });
+  }
+
+  try {
+    const supabase = await createClient();
+
+    // 1. Authenticate user
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      console.error("[chat-export] auth error:", authError);
+      return NextResponse.json(
+        { error: "Unauthorized. You must be logged in to export chat history." },
+        { status: 401 },
+      );
+    }
+
+    // 2. Check room membership (only members can export)
+    const { data: membership, error: memberErr } = await supabase
+      .from("room_members")
+      .select("id, removed_at")
+      .eq("room_id", groupId)
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (memberErr) {
+      console.error("[chat-export] membership check error:", memberErr);
+      return NextResponse.json(
+        { error: "Failed to verify group membership" },
+        { status: 500 },
+      );
+    }
+
+    if (!membership) {
+      return NextResponse.json(
+        { error: "Forbidden. You are not a member of this group." },
+        { status: 403 },
+      );
+    }
+
+    if (membership.removed_at) {
+      return NextResponse.json(
+        { error: "Forbidden. You have been removed from this group." },
+        { status: 403 },
+      );
+    }
+
+    // 3. Fetch room metadata (for naming the export file)
+    const { data: room, error: roomErr } = await supabase
+      .from("rooms")
+      .select("name")
+      .eq("id", groupId)
+      .maybeSingle();
+
+    if (roomErr) {
+      console.error("[chat-export] room lookup error:", roomErr);
+      return NextResponse.json(
+        { error: "Failed to retrieve group details" },
+        { status: 500 },
+      );
+    }
+
+    const groupName = room?.name || "chat-history";
+    const format = request.nextUrl.searchParams.get("format") === "txt" ? "txt" : "json";
+    const filename = `${groupName.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-export.${format}`;
+
+    const encoder = new TextEncoder();
+    const BATCH_SIZE = 1000;
+
+    // 4. Create readable stream for efficient memory scaling with large history
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          let offset = 0;
+          let hasMore = true;
+          let isFirst = true;
+
+          if (format === "json") {
+            controller.enqueue(encoder.encode("[\n"));
+          }
+
+          while (hasMore) {
+            const { data: messages, error: fetchErr } = await supabase
+              .from("messages")
+              .select("*, profiles(display_name)")
+              .eq("room_id", groupId)
+              .order("created_at", { ascending: true })
+              .range(offset, offset + BATCH_SIZE - 1);
+
+            if (fetchErr) {
+              console.error("[chat-export] message fetch error:", fetchErr);
+              throw fetchErr;
+            }
+
+            if (!messages || messages.length === 0) {
+              hasMore = false;
+              break;
+            }
+
+            for (const msg of messages) {
+              if (format === "json") {
+                if (!isFirst) {
+                  controller.enqueue(encoder.encode(",\n"));
+                }
+                const exportMsg = {
+                  id: msg.id,
+                  content: msg.content,
+                  created_at: msg.created_at,
+                  sender: msg.profiles?.display_name || msg.user_id,
+                  is_encrypted: msg.is_encrypted,
+                  edited_at: msg.edited_at,
+                };
+                controller.enqueue(encoder.encode(JSON.stringify(exportMsg)));
+                isFirst = false;
+              } else {
+                const dateStr = new Date(msg.created_at).toISOString().replace("T", " ").substring(0, 19);
+                const senderName = msg.profiles?.display_name || msg.user_id;
+                const txtLine = `[${dateStr}] ${senderName}: ${msg.content}\n`;
+                controller.enqueue(encoder.encode(txtLine));
+              }
+            }
+
+            if (messages.length < BATCH_SIZE) {
+              hasMore = false;
+            } else {
+              offset += BATCH_SIZE;
+            }
+          }
+
+          if (format === "json") {
+            controller.enqueue(encoder.encode("\n]"));
+          }
+
+          controller.close();
+        } catch (err) {
+          console.error("[chat-export] stream generation error:", err);
+          controller.error(err);
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": format === "json" ? "application/json" : "text/plain",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Transfer-Encoding": "chunked",
+      },
+    });
+  } catch (error) {
+    console.error(`[chat-export] GET /api/groups/${groupId}/export unexpected error:`, error);
+    return NextResponse.json({ error: "Failed to export chat history" }, { status: 500 });
+  }
+}

--- a/docs/CHAT_EXPORT_API.md
+++ b/docs/CHAT_EXPORT_API.md
@@ -1,0 +1,88 @@
+# Chat Export API
+
+The Chat Export API allows users to securely and efficiently export their group chat history in either structured JSON format or plain text format.
+
+---
+
+## Endpoint Details
+
+- **Path**: `/api/groups/[id]/export`
+- **Method**: `GET`
+- **Authentication**: Requires a valid Supabase user session.
+- **Authorization**: User must be an active member of the specified group (not removed).
+
+---
+
+## Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `format`  | `string` | No | Export format. Options: `json` (default) or `txt`. |
+
+---
+
+## Response Headers
+
+To facilitate proper downloading and support infinite scalability, responses are streamed directly from the database using standard HTTP Chunked Transfer Encoding.
+
+- `Content-Type`: `application/json` (for JSON) or `text/plain` (for TXT)
+- `Content-Disposition`: `attachment; filename="[group-name]-export.[format]"`
+- `Transfer-Encoding`: `chunked`
+
+---
+
+## Formats & Examples
+
+### 1. JSON Export (`format=json` or default)
+
+The output is streamed as a structured JSON Array.
+
+**URL**: `/api/groups/room-1/export?format=json`
+
+**Response Body**:
+```json
+[
+  {
+    "id": "msg-1",
+    "content": "Hello world",
+    "created_at": "2026-07-27T10:00:00.000Z",
+    "sender": "Alice",
+    "is_encrypted": false,
+    "edited_at": null
+  },
+  {
+    "id": "msg-2",
+    "content": "Hi Alice!",
+    "created_at": "2026-07-27T10:01:00.000Z",
+    "sender": "Bob",
+    "is_encrypted": false,
+    "edited_at": null
+  }
+]
+```
+
+### 2. Plain Text Export (`format=txt`)
+
+The output is streamed as a chronological text file with one message per line.
+
+**URL**: `/api/groups/room-1/export?format=txt`
+
+**Response Body**:
+```text
+[2026-07-27 10:00:00] Alice: Hello world
+[2026-07-27 10:01:00] Bob: Hi Alice!
+```
+
+---
+
+## Technical Design & Performance
+
+### Streaming and Chunking
+Rather than fetching all messages into server memory (which fails for groups with tens of thousands of messages), the export endpoint queries messages in sorted batches of **1,000** and writes them directly to the `ReadableStream` connection. This allows:
+- Constant memory consumption on the server.
+- Immediate byte transmission to the client, improving time-to-first-byte (TTFB).
+- Clean handling of extremely large chat histories.
+
+### Authorization Checks
+1. Fetches current session user. If no session is present, returns `401 Unauthorized`.
+2. Resolves group membership from `room_members` table. If the user is not found or has a non-null `removed_at` timestamp, returns `403 Forbidden`.

--- a/tests/chat-export.test.ts
+++ b/tests/chat-export.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import { GET } from "../app/api/groups/[id]/export/route";
+import { createClient } from "../lib/supabase/server";
+
+vi.mock("../lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+describe("GET /api/groups/[id]/export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 if user is not authenticated", async () => {
+    const mockSupabase = {
+      auth: {
+        getUser: async () => ({ data: { user: null }, error: null }),
+      },
+    };
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as any);
+
+    const req = makeRequest("http://localhost/api/groups/room-1/export");
+    const res = await GET(req, { params: Promise.resolve({ id: "room-1" }) });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain("Unauthorized");
+  });
+
+  it("should return 403 if user is not a member of the group", async () => {
+    const mockSupabase = {
+      auth: {
+        getUser: async () => ({ data: { user: { id: "user-1" } }, error: null }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "room_members") {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  maybeSingle: async () => ({ data: null, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {};
+      }),
+    };
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as any);
+
+    const req = makeRequest("http://localhost/api/groups/room-1/export");
+    const res = await GET(req, { params: Promise.resolve({ id: "room-1" }) });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Forbidden. You are not a member of this room.");
+  });
+
+  it("should return 403 if user was removed from the group", async () => {
+    const mockSupabase = {
+      auth: {
+        getUser: async () => ({ data: { user: { id: "user-1" } }, error: null }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "room_members") {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  maybeSingle: async () => ({ data: { id: "member-1", removed_at: "2026-07-27" }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {};
+      }),
+    };
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as any);
+
+    const req = makeRequest("http://localhost/api/groups/room-1/export");
+    const res = await GET(req, { params: Promise.resolve({ id: "room-1" }) });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Forbidden. You have been removed from this room.");
+  });
+
+  it("should successfully stream JSON export of chat history", async () => {
+    const mockMessages = [
+      {
+        id: "msg-1",
+        content: "Hello",
+        created_at: "2026-07-27T10:00:00Z",
+        user_id: "user-1",
+        is_encrypted: false,
+        edited_at: null,
+        profiles: { display_name: "User One" },
+      },
+      {
+        id: "msg-2",
+        content: "Hi there",
+        created_at: "2026-07-27T10:01:00Z",
+        user_id: "user-2",
+        is_encrypted: false,
+        edited_at: null,
+        profiles: { display_name: "User Two" },
+      },
+    ];
+
+    const mockSupabase = {
+      auth: {
+        getUser: async () => ({ data: { user: { id: "user-1" } }, error: null }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "room_members") {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  maybeSingle: async () => ({ data: { id: "member-1", removed_at: null }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "rooms") {
+          return {
+            select: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({ data: { name: "Cool Group" }, error: null }),
+              }),
+            }),
+          };
+        }
+        if (table === "messages") {
+          return {
+            select: () => ({
+              eq: () => ({
+                order: () => ({
+                  range: async () => ({ data: mockMessages, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {};
+      }),
+    };
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as any);
+
+    const req = makeRequest("http://localhost/api/groups/room-1/export?format=json");
+    const res = await GET(req, { params: Promise.resolve({ id: "room-1" }) });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(res.headers.get("Content-Disposition")).toBe('attachment; filename="cool-group-export.json"');
+
+    const text = await res.text();
+    const parsed = JSON.parse(text);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].content).toBe("Hello");
+    expect(parsed[0].sender).toBe("User One");
+  });
+
+  it("should successfully stream TXT export of chat history", async () => {
+    const mockMessages = [
+      {
+        id: "msg-1",
+        content: "Hello",
+        created_at: "2026-07-27T10:00:00.000Z",
+        user_id: "user-1",
+        is_encrypted: false,
+        edited_at: null,
+        profiles: { display_name: "User One" },
+      },
+    ];
+
+    const mockSupabase = {
+      auth: {
+        getUser: async () => ({ data: { user: { id: "user-1" } }, error: null }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "room_members") {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  maybeSingle: async () => ({ data: { id: "member-1", removed_at: null }, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "rooms") {
+          return {
+            select: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({ data: { name: "Cool Group" }, error: null }),
+              }),
+            }),
+          };
+        }
+        if (table === "messages") {
+          return {
+            select: () => ({
+              eq: () => ({
+                order: () => ({
+                  range: async () => ({ data: mockMessages, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        return {};
+      }),
+    };
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as any);
+
+    const req = makeRequest("http://localhost/api/groups/room-1/export?format=txt");
+    const res = await GET(req, { params: Promise.resolve({ id: "room-1" }) });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/plain");
+    expect(res.headers.get("Content-Disposition")).toBe('attachment; filename="cool-group-export.txt"');
+
+    const text = await res.text();
+    expect(text).toContain("[2026-07-27 10:00:00] User One: Hello");
+  });
+});


### PR DESCRIPTION
Closes #220

## Changes
- **Structured JSON & Plain TXT Exports**
  - Added new RESTful export route at `/api/groups/[id]/export`.
  - Supports `?format=json` (default) and `?format=txt` via URL query parameters.
- **Enforced Group Access Authorization**
  - Verifies presence of a valid Supabase user session.
  - Queries `room_members` table to assert the user is a current member of the room (asserts `removed_at` is null). Returns `401` or `403` on check failures.
- **Infinite Scalability Streaming Design**
  - Uses `ReadableStream` and batches database reads (chunks of 1,000 messages) to stream output. This avoids high memory overhead and enables fast TTFB on large chats.
- **Documentation**
  - Added `docs/CHAT_EXPORT_API.md` with integration guides, response formatting, and query parameters.
- **Unit & Integration Tests**
  - Added `tests/chat-export.test.ts` to test unauthenticated access, non-membership verification, removed status blockages, and JSON/TXT stream formats.
