### PR TITLE
feat(ui): add chat connection status banner with auto-hide functionality (closes #216)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ChatThemeProvider } from "@/lib/chat-theme";
 import { WebSocketProvider } from "@/lib/websocket/context"
+import { ConnectionStatusBanner } from "@/components/ConnectionStatusBanner"
 
 // installed the proper toast module
 import { Toaster } from "react-hot-toast";
@@ -54,6 +55,7 @@ export default function RootLayout({
         >
           <ChatThemeProvider>
             <WebSocketProvider>
+              <ConnectionStatusBanner />
               {children}
             </WebSocketProvider>
           </ChatThemeProvider>

--- a/components/ConnectionStatusBanner.test.tsx
+++ b/components/ConnectionStatusBanner.test.tsx
@@ -1,0 +1,109 @@
+import React from "react"
+import { render, screen, act } from "@testing-library/react"
+import { ConnectionStatusBanner } from "./ConnectionStatusBanner"
+import { useWebSocketContext } from "@/lib/websocket/context"
+import { vi, describe, it, expect, beforeEach } from "vitest"
+
+// Mock the context hook
+vi.mock("@/lib/websocket/context", () => ({
+  useWebSocketContext: vi.fn(),
+}))
+
+describe("ConnectionStatusBanner Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  it("should not render banner on initial load when connected", () => {
+    vi.mocked(useWebSocketContext).mockReturnValue({
+      connectionState: "connected",
+      isConnected: true,
+      send: vi.fn(),
+      on: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    })
+
+    render(<ConnectionStatusBanner />)
+    expect(screen.queryByTestId("connection-status-banner")).toBeNull()
+  })
+
+  it("should display reconnecting banner when connectionState is connecting", () => {
+    vi.mocked(useWebSocketContext).mockReturnValue({
+      connectionState: "connecting",
+      isConnected: false,
+      send: vi.fn(),
+      on: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    })
+
+    render(<ConnectionStatusBanner />)
+    const banner = screen.getByTestId("connection-status-banner")
+    expect(banner).toBeDefined()
+    expect(banner.textContent).toContain("Reconnecting to chat server...")
+  })
+
+  it("should display disconnected banner when connectionState is disconnected", () => {
+    vi.mocked(useWebSocketContext).mockReturnValue({
+      connectionState: "disconnected",
+      isConnected: false,
+      send: vi.fn(),
+      on: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    })
+
+    render(<ConnectionStatusBanner />)
+    const banner = screen.getByTestId("connection-status-banner")
+    expect(banner).toBeDefined()
+    expect(banner.textContent).toContain("Disconnected from chat server. Attempting to reconnect...")
+  })
+
+  it("should display error banner when connectionState is error", () => {
+    vi.mocked(useWebSocketContext).mockReturnValue({
+      connectionState: "error",
+      isConnected: false,
+      send: vi.fn(),
+      on: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    })
+
+    render(<ConnectionStatusBanner />)
+    const banner = screen.getByTestId("connection-status-banner")
+    expect(banner).toBeDefined()
+    expect(banner.textContent).toContain("Connection error. Retrying...")
+  })
+
+  it("should show connection restored banner and then auto-hide after successful reconnection", () => {
+    // 1. Initial state: disconnected
+    const contextMock = {
+      connectionState: "disconnected" as const,
+      isConnected: false,
+      send: vi.fn(),
+      on: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }
+    vi.mocked(useWebSocketContext).mockReturnValue(contextMock)
+
+    const { rerender } = render(<ConnectionStatusBanner />)
+    expect(screen.getByTestId("connection-status-banner").textContent).toContain("Disconnected")
+
+    // 2. Transition state: connected
+    contextMock.connectionState = "connected" as const
+    contextMock.isConnected = true
+    vi.mocked(useWebSocketContext).mockReturnValue(contextMock)
+
+    rerender(<ConnectionStatusBanner />)
+    expect(screen.getByTestId("connection-status-banner").textContent).toContain("Connection restored!")
+
+    // 3. Fast-forward timer to verify it auto-hides
+    act(() => {
+      vi.advanceTimersByTime(3500)
+    })
+    expect(screen.queryByTestId("connection-status-banner")).toBeNull()
+  })
+})

--- a/components/ConnectionStatusBanner.tsx
+++ b/components/ConnectionStatusBanner.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useWebSocketContext } from "@/lib/websocket/context"
+import { useEffect, useState } from "react"
+import { WifiOff, RefreshCw, CheckCircle } from "lucide-react"
+
+export function ConnectionStatusBanner() {
+  const { connectionState } = useWebSocketContext()
+  const [hasBeenDisconnected, setHasBeenDisconnected] = useState(false)
+  const [showConnectedSuccess, setShowConnectedSuccess] = useState(false)
+
+  // Track if we ever lose the connection
+  useEffect(() => {
+    if (connectionState === "disconnected" || connectionState === "error") {
+      setHasBeenDisconnected(true)
+      setShowConnectedSuccess(false)
+    }
+  }, [connectionState])
+
+  // Handle successful reconnection transition
+  useEffect(() => {
+    if (connectionState === "connected" && hasBeenDisconnected) {
+      setShowConnectedSuccess(true)
+      const timer = setTimeout(() => {
+        setHasBeenDisconnected(false)
+        setShowConnectedSuccess(false)
+      }, 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [connectionState, hasBeenDisconnected])
+
+  const showBanner = connectionState !== "connected" || showConnectedSuccess
+
+  if (!showBanner) return null
+
+  let bgColor = "bg-amber-600/95"
+  let textColor = "text-white"
+  let message = "Reconnecting to chat server..."
+  let icon = <RefreshCw className="h-4 w-4 animate-spin shrink-0" />
+
+  if (connectionState === "disconnected") {
+    bgColor = "bg-destructive/95"
+    message = "Disconnected from chat server. Attempting to reconnect..."
+    icon = <WifiOff className="h-4 w-4 shrink-0" />
+  } else if (connectionState === "error") {
+    bgColor = "bg-destructive/95"
+    message = "Connection error. Retrying..."
+    icon = <WifiOff className="h-4 w-4 shrink-0" />
+  } else if (connectionState === "connected" && showConnectedSuccess) {
+    bgColor = "bg-green-600/95"
+    message = "Connection restored!"
+    icon = <CheckCircle className="h-4 w-4 shrink-0" />
+  }
+
+  return (
+    <div
+      className={`fixed top-4 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-2 px-4 py-2 rounded-full text-xs font-semibold shadow-lg backdrop-blur-md transition-all duration-300 pointer-events-none animate-in fade-in slide-in-from-top-2 ${bgColor} ${textColor}`}
+      role="alert"
+      data-testid="connection-status-banner"
+    >
+      {icon}
+      <span>{message}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #216

## Changes
- **WebSocket Connection State Detection**
  - Reads connection state (`connecting`, `connected`, `disconnected`, `error`) in real time from `useWebSocketContext()`.
- **Non-Intrusive Floating Banner**
  - Added `components/ConnectionStatusBanner.tsx` which renders a floating status pill at the top center of the page.
  - Features visual state updates (amber spinner for connecting, red wifi-off icon for disconnected/error, and green checkmark for connection restoration).
- **Reconnection Transition & Auto-Hide**
  - Banner is hidden by default. If a disconnect/error occurs, it becomes active.
  - When connection is re-established, the banner temporarily shifts to a green success banner ("Connection restored!") for 3 seconds before auto-hiding.
- **Root Layout Integration**
  - Rendered globally inside `app/layout.tsx` nested within `WebSocketProvider`.
- **Component Tests**
  - Added test suite `components/ConnectionStatusBanner.test.tsx` to verify standard states and correct timer-based transition behaviors.
